### PR TITLE
Fix demos for IE11 charts-400

### DIFF
--- a/demo/column_and_bar/bar-with-negative-stack.html
+++ b/demo/column_and_bar/bar-with-negative-stack.html
@@ -6,20 +6,20 @@
         <categories>0-4, 5-9, 10-14, 15-19, 20-24, 25-29, 30-34, 35-39, 40-44, 45-49, 50-54, 55-59, 60-64, 65-69, 70-74,
             75-79, 80-84, 85-89, 90-94, 95-99, 100 +
         </categories>
-        <labels step="1"/>
+        <labels step="1"></labels>
     </x-axis>
     <x-axis opposite="true" reversed="false" linked-to="0">
         <categories>0-4, 5-9, 10-14, 15-19, 20-24, 25-29, 30-34, 35-39, 40-44, 45-49, 50-54, 55-59, 60-64, 65-69, 70-74,
             75-79, 80-84, 85-89, 90-94, 95-99, 100 +
         </categories>
-        <labels step="1"/>
+        <labels step="1"></labels>
     </x-axis>
     <y-axis>
         <title text=""></title>
         <labels formatter="function () { return Math.abs(this.value) + '%'; }"></labels>
     </y-axis>
     <plot-options>
-        <series stacking="normal"/>
+        <series stacking="normal"></series>
     </plot-options>
     <tooltip
             formatter="function () { return '<b>' + this.series.name + ', age ' + this.point.category + '</b><br/>' + 'Population: ' + Highcharts.numberFormat(Math.abs(this.point.y), 0) + '%'; }"></tooltip>

--- a/demo/line_and_scatter/basic-line-with-callouts.html
+++ b/demo/line_and_scatter/basic-line-with-callouts.html
@@ -20,7 +20,10 @@
         <data>
           <point>
             <y>21.5</y>
-            <data-labels shape="callout" enabled="true" y="-12" background-color="#FFEBCD" />
+            <data-labels shape="callout" enabled="true" y="-12"
+                         background-color="#FFEBCD">
+
+            </data-labels>
           </point>
         </data>
         <data>
@@ -32,7 +35,9 @@
         <data>
           <point>
             <y>16.6</y>
-            <data-labels shape="callout" enabled="true" y="-12" background-color="#FFEBCD" />
+            <data-labels shape="callout" enabled="true" y="-12"
+                         background-color="#FFEBCD">
+            </data-labels>
           </point>
         </data>
         <data>14.2, 10.3, 6.6, 4.8</data>


### PR DESCRIPTION
Fix data-labels tag for basic-line-with-callouts and
bar-with-negative-stack demos.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/75)
<!-- Reviewable:end -->
