### PR TITLE
Fix parsing tags values always as strings charts-276

### DIFF
--- a/configuration-reader.html
+++ b/configuration-reader.html
@@ -172,20 +172,18 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             return node.hasChildNodes() && node.childNodes.length == 1 && node.childNodes[0].nodeType == 3 && node.textContent.trim() != "";
         },
 
+
         /**
          * Returns a boolean value if text content is 'true' or 'false'. Otherwise, the return value is the text content itself.
          *
          * @param {node} the node to parse the text content
          **/
         _parseTextContent: function (node) {
-            var content = node.textContent;
-            if ("true" == content) {
-                return true;
+            try {
+              return JSON.parse(node.textContent);
+            } catch (e) {
+               return node.textContent;
             }
-            if ("false" == content) {
-                return false;
-            }
-            return content;
         },
 
         /**
@@ -244,7 +242,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
                     } else if (this._multivaluedNodes.indexOf(camelName) !== -1 || dest[camelName] === undefined) {
                         if (this._textContentNodes.indexOf(camelName) === -1 && this._hasOnlyTextContent(node)) {
                             result = this._parseTextContent(node);
-                        } else {
+                        }
+                        else {
                             result = {};
                             this._loadFromNode(result, node);
                             this._loadConfiguration(result, node);

--- a/test/pie-config-test.html
+++ b/test/pie-config-test.html
@@ -13,8 +13,10 @@
     <tooltip point-format="{series.name}: <b>{point.percentage:.1f}%</b>">
     </tooltip>
     <plot-options>
-        <pie start-angle="45" end-angle="180" cursor="pointer">
-            <data-labels enabled="true" format="<b>{point.name}</b>: {point.percentage:.1f} %">
+        <pie  start-angle="45" end-angle="180" cursor="pointer">
+            <data-labels  enabled="true" format="<b>{point.name}</b>: {point.percentage:.1f} %">
+                <distance>-30</distance>
+                <color>rgb(255,0,0)</color>
             </data-labels>
         </pie>
     </plot-options>
@@ -40,6 +42,7 @@
             expect(conf.plotOptions.pie.endAngle).to.equal(180);
             expect(conf.plotOptions.pie.cursor).to.equal("pointer");
             expect(conf.plotOptions.pie.dataLabels).to.exist;
+            expect(conf.plotOptions.pie.dataLabels.distance).to.equal(-30);
             expect(conf.series).to.exist;
             expect(conf.series).not.to.be.empty;
             expect(conf.series[0].data).to.exist;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/86)
<!-- Reviewable:end -->
