### PR TITLE
Proper fix for initing chart with polymer-cli

### DIFF
--- a/configuration-reader.html
+++ b/configuration-reader.html
@@ -103,20 +103,18 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
          * @param {node} parent the node that is parsed for configuration
          **/
         _loadFromNode: function (dest, node) {
-            if (dest !== undefined) {
-                for (var i in node.attributes) {
-                    if (node.attributes.hasOwnProperty(i)) {
-                        var attr = node.attributes[i].name;
-                        if (attr !== undefined) {
-                            var val = node.getAttribute(attr);
-                            var res = this._parseAttribute(val);
-                            dest[this._toCamelCase(attr)] = res;
-                        }
+            for (var i in node.attributes) {
+                if (node.attributes.hasOwnProperty(i)) {
+                    var attr = node.attributes[i].name;
+                    if (attr !== undefined) {
+                        var val = node.getAttribute(attr);
+                        var res = this._parseAttribute(val);
+                        dest[this._toCamelCase(attr)] = res;
                     }
                 }
-                if (this._hasOnlyTextContent(node)) {
-                    dest.text = node.textContent;
-                }
+            }
+            if (this._hasOnlyTextContent(node)) {
+                dest.text = node.textContent;
             }
         },
 

--- a/data-series.html
+++ b/data-series.html
@@ -49,7 +49,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              **/
             _seriesConf: {
                 type: Object,
-                reflectToAttribute:false,
                 value: function () {
                     return {};
                 }
@@ -237,9 +236,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             var parsedValue = this._parseAttribute(value);
             //if value is undefined it shouldn't be set to keep _seriesConf minimal
             if (undefined !== parsedValue) {
-                if(!this._seriesConf) {
-                    this._seriesConf={};
-                }
                 if (undefined === this._seriesConf[name]) {
                     this._seriesConf[name] = parsedValue;
                 } else if (name === 'data') {
@@ -248,6 +244,10 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             }
         },
 
+        created: function() {
+            // Make sure that seriesConf is initialized
+            this._seriesConf = this.properties._seriesConf.value();
+        },
 
         // Kind of attached but attached is not called then the element is only in the light DOM
         _initialize: function () {


### PR DESCRIPTION
Element properties are not initialized before element (data-series) is attached (https://github.com/Polymer/polymer/issues/1886).

Data-series must be initialized before it is attached because it is used only in light dom  (https://github.com/vaadin/vaadin-charts/commit/006b2f6ca7851f326e7daa5c539d1a6795ffff1d).

This fix is the most "proper fix".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/130)
<!-- Reviewable:end -->
