### PR TITLE
Fix vaadin-grid version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -44,7 +44,7 @@
     "web-component-tester": "^6.0.0",
     "jquery": "^2.2.2",
     "webcomponentsjs": "^v1.0.0",
-    "vaadin-grid": "#2.1-polymer-2"
+    "vaadin-grid": "^3.0.0"
   },
   "resolutions": {
     "polymer": "^2.0.0",


### PR DESCRIPTION
Previous tag was deleted from vaadin-grid repo, so bower building was failing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/172)
<!-- Reviewable:end -->
