### PR TITLE
Fix <vaadin-chart-resize> to work as the old version

### DIFF
--- a/test/resize-test.html
+++ b/test/resize-test.html
@@ -16,6 +16,11 @@
     <test-fixture id="TestElement">
       <template>
         <x-resizable>
+          <vaadin-line-chart id="line">
+            <data-series name="New York">
+              <data>-0.2, 0.8, 5.7, 11.3, 17.0, 22.0, 24.8, 24.1, 20.1, 14.1, 8.6, 2.5</data>
+            </data-series>
+          </vaadin-line-chart>
         </x-resizable>
       </template>
     </test-fixture>
@@ -26,7 +31,8 @@
 
         test('Checks that calling resize on parent, resizes chart', function (done) {
           var testEl = fixture('TestElement');
-          var chart = testEl.$.line;
+          var chart = testEl.querySelector('#line');
+
           chart.addEventListener('iron-resize', function (event) {
             done();
           });

--- a/test/x-resizable.html
+++ b/test/x-resizable.html
@@ -3,11 +3,7 @@
 
 <dom-module id="x-resizable">
   <template>
-    <vaadin-line-chart id="line">
-      <data-series name="New York">
-        <data>-0.2, 0.8, 5.7, 11.3, 17.0, 22.0, 24.8, 24.1, 20.1, 14.1, 8.6, 2.5</data>
-      </data-series>
-    </vaadin-line-chart>
+    <slot></slot>
   </template>
   <script>
     Polymer({


### PR DESCRIPTION
This fix rollbacks some workaround to make this test pass after
upgrading to Polymer 2. Now it works as the old version used to
work, with <x-resizable> component being just a container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/173)
<!-- Reviewable:end -->
