### PR TITLE
Remove commands on Travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,3 @@ script:
 before_deploy:
   - openssl aes-256-cbc -K $encrypted_ccccac989772_key -iv $encrypted_ccccac989772_iv
     -in deploy_rsa.enc -out deploy_rsa -d
-  - eval "$(ssh-agent -s)"
-  - chmod 600 /tmp/deploy_rsa
-  - ssh-add /tmp/deploy_rsa


### PR DESCRIPTION
Keep only the `openssl` command added by Travis cli

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/195)
<!-- Reviewable:end -->
