### PR TITLE
Add Basic Use section to JSDOC

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -8,17 +8,17 @@
       "sourceRange": {
         "file": "vaadin-chart.html",
         "start": {
-          "line": 303,
+          "line": 311,
           "column": 6
         },
         "end": {
-          "line": 303,
+          "line": 311,
           "column": 42
         }
       },
       "elements": [
         {
-          "description": "`<vaadin-chart>` is a Polymer 2 element for creating high quality charts.\n\n### Quick Start\n\n1. Create a Polymer application using [Polymer CLI](https://www.polymer-project.org/2.0/docs/tools/polymer-cli)\n```\nmkdir my-app\ncd my-app\npolymer init\nselect `polymer-2-application`\n```\n1. Install Vaadin Charts\n```\nbower install --save vaadin-charts#6.0-preview\n```\n1. Import `<vaadin-chart>` to your app\nEdit the file `src/my-app/my-app.html` and add the following snipped before the `<dom-module>` tag\n```html\n<link rel=\"import\" href=\"../../bower_components/vaadin-charts/vaadin-chart.html\">\n```\n1. Add your first `<vaadin-chart>`\nAlso in `my-app.html` add the following snippet before the `</template>` closing tag\n```html\n<vaadin-chart></vaadin-chart>\n```\n1. Run your app with: \n```\npolymer serve --open\n```\nCongratulations! You have your first Vaadin Chart setup.\n\n### Configuring your chart using JS API \n\nUsing as a base the project created with in Quick Start\n\nDo the following changes in `my-app.html`\n\n1. Set and id for the `<vaadin-chart>` in the template\n```html\n    <vaadin-chart id=\"mychart\"></vaadin-chart>\n```\n1. Add a function that uses `configuration` property (JS Api) to set chart title, categories and data\n```\ninitChartWithJSApi() {\n    const configuration = this.$.mychart.configuration;\n    configuration.setTitle({ text: 'The chart title' });\n    // By default there is one x axis, it is referenced by configuration.xAxis[0].\n    configuration.xAxis[0].setCategories(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']);\n    configuration.addSeries({\n      type: 'column',\n      data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]\n    });\n}\n```\n1. Call that function from connectedCallback (when the element is added to a document)\n```\nconnectedCallback() {\n    super.connectedCallback();\n    this.initChartWithJSApi();\n}\n```\n1. And finally run your app with: \n```\npolymer serve --open\n```\n\n\n### Configuring your chart using JS JSON API \n\nJS JSON API is a simple alternative to the JS API.\n\nUsing as a base the project created with in Quick Start\n\nDo the following changes in `my-app.html`\n\n1. Set and id for the `<vaadin-chart>` in the template\n```html\n    <vaadin-chart id=\"mychart\"></vaadin-chart>\n```\n1. Add a function that uses `update` method (JS JSON Api) to set chart title, categories and data\n```\ninitChartWithJSJSONApi() {\n    this.$.mychart.update({\n      title: {\n        text: 'The chart title'\n      },\n      subtitle: {\n        text: 'Subtitle'\n      },\n      xAxis: {\n        categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']\n      },\n      series: [{\n        type: 'column',\n        data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]\n      }]\n    });\n}\n```\n1. Call that function from connectedCallback (when the element is added to a document)\n```\nconnectedCallback() {\n    super.connectedCallback();\n    this.initChartWithJSJSONApi();\n}\n```\n1. And finally run your app with: \n```\npolymer serve --open\n```\n\n### Install License Key\nAfter one day using Vaadin Charts in a development environment you will see a pop-up that asks you to enter the license key. \n\nYou can get your trial key from [https://vaadin.com/pro/licenses](https://vaadin.com/pro/licenses).\n\nIf the license is valid, it will be saved to the local storage of the browser and you will not see the pop-up again",
+          "description": "`<vaadin-chart>` is a Polymer 2 element for creating high quality charts.\n\n### Quick Start\n\n1. Create a Polymer application using [Polymer CLI](https://www.polymer-project.org/2.0/docs/tools/polymer-cli)\n```\nmkdir my-app\ncd my-app\npolymer init\nselect `polymer-2-application`\n```\n1. Install Vaadin Charts\n```\nbower install --save vaadin-charts#6.0-preview\n```\n1. Import `<vaadin-chart>` to your app\nEdit the file `src/my-app/my-app.html` and add the following snipped before the `<dom-module>` tag\n```html\n<link rel=\"import\" href=\"../../bower_components/vaadin-charts/vaadin-chart.html\">\n```\n1. Add your first `<vaadin-chart>`\nAlso in `my-app.html` add the following snippet before the `</template>` closing tag\n```html\n<vaadin-chart></vaadin-chart>\n```\n1. Run your app with: \n```\npolymer serve --open\n```\nCongratulations! You have your first Vaadin Chart setup.\n\n### Basic use\n\nNow that we covered the basic steps to create an empty chart, let us show how you can configure it.\n\nThere are two ways of configuring your `<vaadin-chart>` element: **JS API** and **JSON API**.\nNote that you can make use of both APIs in your element.\n\n#### Configuring your chart using JS API\n\nUsing as a base the project created with in Quick Start\n\nDo the following changes in `my-app.html`\n\n1. Set and id for the `<vaadin-chart>` in the template\n```html\n    <vaadin-chart id=\"mychart\"></vaadin-chart>\n```\n1. Add a function that uses `configuration` property (JS Api) to set chart title, categories and data\n```\ninitChartWithJSApi() {\n    const configuration = this.$.mychart.configuration;\n    configuration.setTitle({ text: 'The chart title' });\n    // By default there is one x axis, it is referenced by configuration.xAxis[0].\n    configuration.xAxis[0].setCategories(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']);\n    configuration.addSeries({\n      type: 'column',\n      data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]\n    });\n}\n```\n1. Call that function from connectedCallback (when the element is added to a document)\n```\nconnectedCallback() {\n    super.connectedCallback();\n    this.initChartWithJSApi();\n}\n```\n1. And finally run your app with: \n```\npolymer serve --open\n```\n\n\n#### Configuring your chart using JS JSON API\n\nJS JSON API is a simple alternative to the JS API.\n\nUsing as a base the project created with in Quick Start\n\nDo the following changes in `my-app.html`\n\n1. Set and id for the `<vaadin-chart>` in the template\n```html\n    <vaadin-chart id=\"mychart\"></vaadin-chart>\n```\n1. Add a function that uses `update` method (JS JSON Api) to set chart title, categories and data\n```\ninitChartWithJSJSONApi() {\n    this.$.mychart.update({\n      title: {\n        text: 'The chart title'\n      },\n      subtitle: {\n        text: 'Subtitle'\n      },\n      xAxis: {\n        categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']\n      },\n      series: [{\n        type: 'column',\n        data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]\n      }]\n    });\n}\n```\n1. Call that function from connectedCallback (when the element is added to a document)\n```\nconnectedCallback() {\n    super.connectedCallback();\n    this.initChartWithJSJSONApi();\n}\n```\n1. And finally run your app with: \n```\npolymer serve --open\n```\n\n### Install License Key\nAfter one day using Vaadin Charts in a development environment you will see a pop-up that asks you to enter the license key. \n\nYou can get your trial key from [https://vaadin.com/pro/licenses](https://vaadin.com/pro/licenses).\n\nIf the license is valid, it will be saved to the local storage of the browser and you will not see the pop-up again",
           "summary": "",
           "path": "vaadin-chart.html",
           "properties": [
@@ -53,11 +53,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 27
                 }
               },
@@ -145,11 +145,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1133,
+                  "line": 1134,
                   "column": 8
                 },
                 "end": {
-                  "line": 1133,
+                  "line": 1134,
                   "column": 20
                 }
               },
@@ -168,11 +168,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1135,
+                  "line": 1136,
                   "column": 8
                 },
                 "end": {
-                  "line": 1135,
+                  "line": 1136,
                   "column": 27
                 }
               },
@@ -191,11 +191,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1137,
+                  "line": 1138,
                   "column": 8
                 },
                 "end": {
-                  "line": 1137,
+                  "line": 1138,
                   "column": 23
                 }
               },
@@ -283,11 +283,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1115,
+                  "line": 1116,
                   "column": 8
                 },
                 "end": {
-                  "line": 1115,
+                  "line": 1116,
                   "column": 32
                 }
               },
@@ -306,11 +306,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1117,
+                  "line": 1118,
                   "column": 8
                 },
                 "end": {
-                  "line": 1117,
+                  "line": 1118,
                   "column": 34
                 }
               },
@@ -329,11 +329,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1119,
+                  "line": 1120,
                   "column": 8
                 },
                 "end": {
-                  "line": 1119,
+                  "line": 1120,
                   "column": 28
                 }
               },
@@ -352,11 +352,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1121,
+                  "line": 1122,
                   "column": 8
                 },
                 "end": {
-                  "line": 1121,
+                  "line": 1122,
                   "column": 31
                 }
               },
@@ -375,11 +375,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1123,
+                  "line": 1124,
                   "column": 8
                 },
                 "end": {
-                  "line": 1123,
+                  "line": 1124,
                   "column": 28
                 }
               },
@@ -398,11 +398,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1125,
+                  "line": 1126,
                   "column": 8
                 },
                 "end": {
-                  "line": 1125,
+                  "line": 1126,
                   "column": 35
                 }
               },
@@ -421,11 +421,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1127,
+                  "line": 1128,
                   "column": 8
                 },
                 "end": {
-                  "line": 1127,
+                  "line": 1128,
                   "column": 24
                 }
               },
@@ -444,11 +444,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1129,
+                  "line": 1130,
                   "column": 8
                 },
                 "end": {
-                  "line": 1129,
+                  "line": 1130,
                   "column": 24
                 }
               },
@@ -467,11 +467,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1131,
+                  "line": 1132,
                   "column": 8
                 },
                 "end": {
-                  "line": 1131,
+                  "line": 1132,
                   "column": 38
                 }
               },
@@ -490,11 +490,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1139,
+                  "line": 1140,
                   "column": 8
                 },
                 "end": {
-                  "line": 1139,
+                  "line": 1140,
                   "column": 30
                 }
               },
@@ -513,11 +513,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1141,
+                  "line": 1142,
                   "column": 8
                 },
                 "end": {
-                  "line": 1141,
+                  "line": 1142,
                   "column": 30
                 }
               },
@@ -536,11 +536,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1143,
+                  "line": 1144,
                   "column": 8
                 },
                 "end": {
-                  "line": 1143,
+                  "line": 1144,
                   "column": 29
                 }
               },
@@ -559,11 +559,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1145,
+                  "line": 1146,
                   "column": 8
                 },
                 "end": {
-                  "line": 1145,
+                  "line": 1146,
                   "column": 32
                 }
               },
@@ -582,11 +582,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 30
                 }
               },
@@ -605,11 +605,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 24
                 }
               },
@@ -628,11 +628,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 28
                 }
               },
@@ -644,17 +644,155 @@
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
+              "name": "_template",
+              "type": "HTMLTemplateElement",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 549,
+                  "column": 8
+                },
+                "end": {
+                  "line": 549,
+                  "column": 23
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_importPath",
+              "type": "string",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 551,
+                  "column": 8
+                },
+                "end": {
+                  "line": 551,
+                  "column": 25
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "rootPath",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 553,
+                  "column": 8
+                },
+                "end": {
+                  "line": 553,
+                  "column": 22
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "importPath",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 555,
+                  "column": 8
+                },
+                "end": {
+                  "line": 555,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "root",
+              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 557,
+                  "column": 8
+                },
+                "end": {
+                  "line": 557,
+                  "column": 18
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "$",
+              "type": "!Object.<string, !Node>",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 559,
+                  "column": 8
+                },
+                "end": {
+                  "line": 559,
+                  "column": 15
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
               "name": "configuration",
               "type": "Object",
-              "description": "Configuration object that exposes the JS Api to configure the chart.\n\nMost important methods are:\n- `addSeries (Object options, [Boolean redraw], [Mixed animation])`\n- `addAxis (Object options, [Boolean isX], [Boolean redraw], [Mixed animation])`\n- `setTitle (Object title, object subtitle, Boolean redraw)`\n\nMost important properties are:\n- `configuration.series`: An array of the chart's series. Detailed API for Series object is\n    available in [API Site](http://api.highcharts.com/highcharts/Series)\n- `configuration.xAxis`: An array of the chart's x axes. Detailed API for Axis object is\n    available in [API Site](http://api.highcharts.com/highcharts/Axis)\n- `configuration.yAxis`: An array of the chart's y axes. Detailed API for Axis object is\n    available in [API Site](http://api.highcharts.com/highcharts/Axis)\n- `configuration.title`: The chart title.\n\nFor detailed documentation of available API check the [API site](http://api.highcharts.com/highcharts/Chart)",
+              "description": "Configuration object that exposes the JS Api to configure the chart.\n\nMost important methods are:\n- `addSeries (Object options, [Boolean redraw], [Mixed animation])`\n- `addAxis (Object options, [Boolean isX], [Boolean redraw], [Mixed animation])`\n- `setTitle (Object title, object subtitle, Boolean redraw)`\n\nMost important properties are:\n- `configuration.series`: An array of the chart's series. Detailed API for Series object is\n    available in [API Site](http://api.highcharts.com/highcharts/series)\n- `configuration.xAxis`: An array of the chart's x axes. Detailed API for Axis object is\n    available in [API Site](http://api.highcharts.com/highcharts/xAxis)\n- `configuration.yAxis`: An array of the chart's y axes. Detailed API for Axis object is\n    available in [API Site](http://api.highcharts.com/highcharts/yAxis)\n- `configuration.title`: The chart title.\n\nFor detailed documentation of available API check the [API site](http://api.highcharts.com/highcharts/chart)",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 181,
+                  "line": 188,
                   "column": 12
                 },
                 "end": {
-                  "line": 181,
+                  "line": 188,
                   "column": 33
                 }
               },
@@ -671,11 +809,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2319,
+                  "line": 2320,
                   "column": 6
                 },
                 "end": {
-                  "line": 2344,
+                  "line": 2345,
                   "column": 7
                 }
               },
@@ -700,11 +838,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 447,
+                  "line": 451,
                   "column": 6
                 },
                 "end": {
-                  "line": 452,
+                  "line": 456,
                   "column": 7
                 }
               },
@@ -744,11 +882,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 461,
+                  "line": 465,
                   "column": 6
                 },
                 "end": {
-                  "line": 463,
+                  "line": 467,
                   "column": 7
                 }
               },
@@ -779,11 +917,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 472,
+                  "line": 476,
                   "column": 6
                 },
                 "end": {
-                  "line": 474,
+                  "line": 478,
                   "column": 7
                 }
               },
@@ -809,16 +947,16 @@
             },
             {
               "name": "attributeChangedCallback",
-              "description": "Provides a default implementation of the standard Custom Elements\n`attributeChangedCallback`.\n\nBy default, attributes declared in `properties` metadata are\ndeserialized using their `type` information to properties of the\nsame name.  \"Dash-cased\" attributes are deserialzed to \"camelCase\"\nproperties.",
+              "description": "Provides a default implementation of the standard Custom Elements\n`attributeChangedCallback`.\n\nBy default, attributes declared in `properties` metadata are\ndeserialized using their `type` information to properties of the\nsame name.  \"Dash-cased\" attributes are deserialized to \"camelCase\"\nproperties.",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 699,
+                  "line": 715,
                   "column": 6
                 },
                 "end": {
-                  "line": 707,
+                  "line": 723,
                   "column": 7
                 }
               },
@@ -849,11 +987,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 557,
+                  "line": 573,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 613,
                   "column": 7
                 }
               },
@@ -868,11 +1006,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 6
                 },
                 "end": {
-                  "line": 1187,
+                  "line": 1188,
                   "column": 7
                 }
               },
@@ -893,11 +1031,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1196,
+                  "line": 1197,
                   "column": 6
                 },
                 "end": {
-                  "line": 1205,
+                  "line": 1206,
                   "column": 7
                 }
               },
@@ -1175,11 +1313,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1472,
+                  "line": 1473,
                   "column": 6
                 },
                 "end": {
-                  "line": 1476,
+                  "line": 1477,
                   "column": 7
                 }
               },
@@ -1196,16 +1334,16 @@
             },
             {
               "name": "_setPendingProperty",
-              "description": "Overrides the `PropertyAccessors` implementation to introduce special\ndirty check logic depending on the property & value being set:\n\n1. Any value set to a path (e.g. 'obj.prop': 42 or 'obj.prop': {...})\n   Stored in `__dataTemp`, dirty checked against `__dataTemp`\n2. Object set to simple property (e.g. 'prop': {...})\n   Stored in `__dataTemp` and `__data`, dirty checked against\n   `__dataTemp` by default implementation of `_shouldPropertyChange`\n3. Primitive value set to simple property (e.g. 'prop': 42)\n   Stored in `__data`, dirty checked against `__data`\n\nThe dirty-check is important to prevent cycles due to two-way\nnotification, but paths and objects are only dirty checked against any\nprevious value set during this turn via a \"temporary cache\" that is\ncleared when the last `_propertiesChaged` exits. This is so:\na. any cached array paths (e.g. 'array.3.prop') may be invalidated\n   due to array mutations like shift/unshift/splice; this is fine\n   since path changes are dirty-checked at user entry points like `set`\nb. dirty-checking for objects only lasts one turn to allow the user\n   to mutate the object in-place and re-set it with the same identity\n   and have all sub-properties re-propagated in a subsequent turn.\n\nThe temp cache is not necessarily sufficient to prevent invalid array\npaths, since a splice can happen during the same turn (with pathological\nuser code); we could introduce a \"fixup\" for temporarily cached array\npaths if needed: https://github.com/Polymer/polymer/issues/4227",
+              "description": "Overrides the `PropertyAccessors` implementation to introduce special\ndirty check logic depending on the property & value being set:\n\n1. Any value set to a path (e.g. 'obj.prop': 42 or 'obj.prop': {...})\n   Stored in `__dataTemp`, dirty checked against `__dataTemp`\n2. Object set to simple property (e.g. 'prop': {...})\n   Stored in `__dataTemp` and `__data`, dirty checked against\n   `__dataTemp` by default implementation of `_shouldPropertyChange`\n3. Primitive value set to simple property (e.g. 'prop': 42)\n   Stored in `__data`, dirty checked against `__data`\n\nThe dirty-check is important to prevent cycles due to two-way\nnotification, but paths and objects are only dirty checked against any\nprevious value set during this turn via a \"temporary cache\" that is\ncleared when the last `_propertiesChanged` exits. This is so:\na. any cached array paths (e.g. 'array.3.prop') may be invalidated\n   due to array mutations like shift/unshift/splice; this is fine\n   since path changes are dirty-checked at user entry points like `set`\nb. dirty-checking for objects only lasts one turn to allow the user\n   to mutate the object in-place and re-set it with the same identity\n   and have all sub-properties re-propagated in a subsequent turn.\n\nThe temp cache is not necessarily sufficient to prevent invalid array\npaths, since a splice can happen during the same turn (with pathological\nuser code); we could introduce a \"fixup\" for temporarily cached array\npaths if needed: https://github.com/Polymer/polymer/issues/4227",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1435,
+                  "line": 1436,
                   "column": 6
                 },
                 "end": {
-                  "line": 1464,
+                  "line": 1465,
                   "column": 7
                 }
               },
@@ -1269,11 +1407,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1486,
+                  "line": 1487,
                   "column": 6
                 },
                 "end": {
-                  "line": 1490,
+                  "line": 1491,
                   "column": 7
                 }
               },
@@ -1326,11 +1464,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 627,
+                  "line": 643,
                   "column": 6
                 },
                 "end": {
-                  "line": 633,
+                  "line": 649,
                   "column": 7
                 }
               },
@@ -1345,11 +1483,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1625,
+                  "line": 1626,
                   "column": 6
                 },
                 "end": {
-                  "line": 1658,
+                  "line": 1659,
                   "column": 7
                 }
               },
@@ -1378,7 +1516,7 @@
                   "column": 6
                 },
                 "end": {
-                  "line": 613,
+                  "line": 609,
                   "column": 7
                 }
               },
@@ -1402,7 +1540,7 @@
               ],
               "return": {
                 "type": "boolean",
-                "desc": "Whether the property should be considered a change\n  and enqueue a `_proeprtiesChanged` callback"
+                "desc": "Whether the property should be considered a change\n  and enqueue a `_propertiesChanged` callback"
               },
               "inheritedFrom": "Polymer.PropertyAccessors"
             },
@@ -1413,11 +1551,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1219,
+                  "line": 1220,
                   "column": 6
                 },
                 "end": {
-                  "line": 1227,
+                  "line": 1228,
                   "column": 7
                 }
               },
@@ -1448,11 +1586,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1236,
+                  "line": 1237,
                   "column": 6
                 },
                 "end": {
-                  "line": 1242,
+                  "line": 1243,
                   "column": 7
                 }
               },
@@ -1483,11 +1621,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1253,
+                  "line": 1254,
                   "column": 6
                 },
                 "end": {
-                  "line": 1256,
+                  "line": 1257,
                   "column": 7
                 }
               },
@@ -1517,11 +1655,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1266,
+                  "line": 1267,
                   "column": 6
                 },
                 "end": {
-                  "line": 1268,
+                  "line": 1269,
                   "column": 7
                 }
               },
@@ -1546,11 +1684,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1278,
+                  "line": 1279,
                   "column": 6
                 },
                 "end": {
-                  "line": 1280,
+                  "line": 1281,
                   "column": 7
                 }
               },
@@ -1575,11 +1713,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1292,
+                  "line": 1293,
                   "column": 7
                 }
               },
@@ -1604,11 +1742,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1302,
+                  "line": 1303,
                   "column": 6
                 },
                 "end": {
-                  "line": 1304,
+                  "line": 1305,
                   "column": 7
                 }
               },
@@ -1633,11 +1771,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1336,
+                  "line": 1337,
                   "column": 6
                 },
                 "end": {
-                  "line": 1368,
+                  "line": 1369,
                   "column": 7
                 }
               },
@@ -1677,11 +1815,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1390,
+                  "line": 1391,
                   "column": 6
                 },
                 "end": {
-                  "line": 1398,
+                  "line": 1399,
                   "column": 7
                 }
               },
@@ -1712,11 +1850,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1500,
+                  "line": 1501,
                   "column": 6
                 },
                 "end": {
-                  "line": 1505,
+                  "line": 1506,
                   "column": 7
                 }
               },
@@ -1737,11 +1875,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1513,
+                  "line": 1514,
                   "column": 6
                 },
                 "end": {
-                  "line": 1524,
+                  "line": 1525,
                   "column": 7
                 }
               },
@@ -1756,11 +1894,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1538,
+                  "line": 1539,
                   "column": 6
                 },
                 "end": {
-                  "line": 1551,
+                  "line": 1552,
                   "column": 7
                 }
               },
@@ -1775,11 +1913,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 644,
+                  "line": 660,
                   "column": 6
                 },
                 "end": {
-                  "line": 653,
+                  "line": 669,
                   "column": 7
                 }
               },
@@ -1794,11 +1932,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1578,
+                  "line": 1579,
                   "column": 6
                 },
                 "end": {
-                  "line": 1589,
+                  "line": 1590,
                   "column": 7
                 }
               },
@@ -1824,11 +1962,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1669,
+                  "line": 1670,
                   "column": 6
                 },
                 "end": {
-                  "line": 1679,
+                  "line": 1680,
                   "column": 7
                 }
               },
@@ -1859,11 +1997,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1689,
+                  "line": 1690,
                   "column": 6
                 },
                 "end": {
-                  "line": 1694,
+                  "line": 1695,
                   "column": 7
                 }
               },
@@ -1889,11 +2027,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1705,
+                  "line": 1706,
                   "column": 6
                 },
                 "end": {
-                  "line": 1710,
+                  "line": 1711,
                   "column": 7
                 }
               },
@@ -1909,16 +2047,16 @@
             },
             {
               "name": "notifySplices",
-              "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, obect: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
+              "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1741,
+                  "line": 1742,
                   "column": 6
                 },
                 "end": {
-                  "line": 1745,
+                  "line": 1746,
                   "column": 7
                 }
               },
@@ -1944,11 +2082,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1766,
+                  "line": 1767,
                   "column": 6
                 },
                 "end": {
-                  "line": 1768,
+                  "line": 1769,
                   "column": 7
                 }
               },
@@ -1978,11 +2116,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1790,
+                  "line": 1791,
                   "column": 6
                 },
                 "end": {
-                  "line": 1800,
+                  "line": 1801,
                   "column": 7
                 }
               },
@@ -2013,11 +2151,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1816,
+                  "line": 1817,
                   "column": 6
                 },
                 "end": {
-                  "line": 1825,
+                  "line": 1826,
                   "column": 7
                 }
               },
@@ -2025,7 +2163,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "string",
+                  "type": "(string|!Array.<(string|number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -2045,11 +2183,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1840,
+                  "line": 1841,
                   "column": 6
                 },
                 "end": {
-                  "line": 1849,
+                  "line": 1850,
                   "column": 7
                 }
               },
@@ -2057,7 +2195,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "string",
+                  "type": "(string|!Array.<(string|number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -2074,11 +2212,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1868,
+                  "line": 1869,
                   "column": 6
                 },
                 "end": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 7
                 }
               },
@@ -2086,7 +2224,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "string",
+                  "type": "(string|!Array.<(string|number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -2116,11 +2254,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1900,
+                  "line": 1901,
                   "column": 6
                 },
                 "end": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 7
                 }
               },
@@ -2128,7 +2266,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "string",
+                  "type": "(string|!Array.<(string|number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -2145,11 +2283,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1925,
+                  "line": 1926,
                   "column": 6
                 },
                 "end": {
-                  "line": 1933,
+                  "line": 1934,
                   "column": 7
                 }
               },
@@ -2157,7 +2295,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "string",
+                  "type": "(string|!Array.<(string|number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -2177,11 +2315,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1947,
+                  "line": 1948,
                   "column": 6
                 },
                 "end": {
-                  "line": 1964,
+                  "line": 1965,
                   "column": 7
                 }
               },
@@ -2207,11 +2345,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1976,
+                  "line": 1977,
                   "column": 6
                 },
                 "end": {
-                  "line": 1983,
+                  "line": 1984,
                   "column": 7
                 }
               },
@@ -2237,11 +2375,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1996,
+                  "line": 1997,
                   "column": 6
                 },
                 "end": {
-                  "line": 2006,
+                  "line": 2007,
                   "column": 7
                 }
               },
@@ -2272,11 +2410,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2018,
+                  "line": 2019,
                   "column": 6
                 },
                 "end": {
-                  "line": 2024,
+                  "line": 2025,
                   "column": 7
                 }
               },
@@ -2302,11 +2440,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2034,
+                  "line": 2035,
                   "column": 6
                 },
                 "end": {
-                  "line": 2042,
+                  "line": 2043,
                   "column": 7
                 }
               },
@@ -2327,11 +2465,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2052,
+                  "line": 2053,
                   "column": 6
                 },
                 "end": {
-                  "line": 2065,
+                  "line": 2066,
                   "column": 7
                 }
               },
@@ -2352,11 +2490,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2078,
+                  "line": 2079,
                   "column": 6
                 },
                 "end": {
-                  "line": 2084,
+                  "line": 2085,
                   "column": 7
                 }
               },
@@ -2387,11 +2525,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2254,
+                  "line": 2255,
                   "column": 6
                 },
                 "end": {
-                  "line": 2277,
+                  "line": 2278,
                   "column": 7
                 }
               },
@@ -2421,11 +2559,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2354,
+                  "line": 2355,
                   "column": 6
                 },
                 "end": {
-                  "line": 2375,
+                  "line": 2376,
                   "column": 7
                 }
               },
@@ -2442,14 +2580,14 @@
             {
               "name": "connectedCallback",
               "description": "",
-              "privacy": "public",
+              "privacy": "private",
               "sourceRange": {
                 "start": {
-                  "line": 194,
+                  "line": 202,
                   "column": 8
                 },
                 "end": {
-                  "line": 198,
+                  "line": 206,
                   "column": 9
                 }
               },
@@ -2463,11 +2601,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 636,
                   "column": 6
                 },
                 "end": {
-                  "line": 620,
+                  "line": 636,
                   "column": 31
                 }
               },
@@ -2482,11 +2620,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 667,
+                  "line": 683,
                   "column": 6
                 },
                 "end": {
-                  "line": 683,
+                  "line": 699,
                   "column": 7
                 }
               },
@@ -2494,12 +2632,12 @@
               "params": [
                 {
                   "name": "dom",
-                  "type": "NodeList",
+                  "type": "StampedTemplate",
                   "description": "to attach to the element."
                 }
               ],
               "return": {
-                "type": "Node",
+                "type": "ShadowRoot",
                 "desc": "node to which the dom has been attached."
               },
               "inheritedFrom": "Polymer.ElementMixin"
@@ -2511,11 +2649,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 726,
+                  "line": 742,
                   "column": 6
                 },
                 "end": {
-                  "line": 730,
+                  "line": 746,
                   "column": 7
                 }
               },
@@ -2536,11 +2674,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 743,
+                  "line": 759,
                   "column": 6
                 },
                 "end": {
-                  "line": 748,
+                  "line": 764,
                   "column": 7
                 }
               },
@@ -2569,11 +2707,11 @@
               "privacy": "private",
               "sourceRange": {
                 "start": {
-                  "line": 200,
+                  "line": 208,
                   "column": 8
                 },
                 "end": {
-                  "line": 206,
+                  "line": 214,
                   "column": 9
                 }
               },
@@ -2586,11 +2724,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 240,
+                  "line": 248,
                   "column": 8
                 },
                 "end": {
-                  "line": 258,
+                  "line": 266,
                   "column": 9
                 }
               },
@@ -2599,7 +2737,7 @@
                 {
                   "name": "jsonConfiguration",
                   "type": "Object",
-                  "description": "Object chart configuration. Most important properties are:\n \n- chart `Object` with options regarding the chart area and plot area as well as general chart options.  \n   Detailed API for chart object is available in [API Site](http://api.highcharts.com/highcharts/chart)\n- credits `Object` with options regarding the chart area and plot area as well as general chart options.  \n   Detailed API for credits object is available in [API Site](http://api.highcharts.com/highcharts/credits)\n- labels `Object[]` with HTML labels that can be positioned anywhere in the chart area\n   Detailed API for labels object is available in [API Site](http://api.highcharts.com/highcharts/labels)\n- plotOptions `Object` wrapper for config objects for each series type.  \n   Detailed API for plotOptions object is available in [API Site](http://api.highcharts.com/highcharts/plotOptions)\n- series `Object[]` the actual series to append to the chart.  \n   Detailed API for series object is available in [API Site](http://api.highcharts.com/highcharts/series)\n- subtitle `Object` the chart's subtitle.  \n   Detailed API for subtitle object is available in [API Site](http://api.highcharts.com/highcharts/subtitle)\n- title `Object` the chart's main title.\n   Detailed API for title object is available in [API Site](http://api.highcharts.com/highcharts/title)\n- tooltip `Object` Options for the tooltip that appears when the user hovers over a series or point.  \n   Detailed API for tooltip object is available in [API Site](http://api.highcharts.com/highcharts/tooltip)\n- xAxis `Object[]` The X axis or category axis. Normally this is the horizontal axis.  \n   Detailed API for xAxis object is available in [API Site](http://api.highcharts.com/highcharts/xAxis)\n- yAxis `Object[]` The Y axis or value axis. Normally this is the vertical axis.  \n   Detailed API for yAxis object is available in [API Site](http://api.highcharts.com/highcharts/yAxis)\n- zAxis `Object[]` The Z axis or depth axis for 3D plots.  \n   Detailed API for zAxis object is available in [API Site](http://api.highcharts.com/highcharts/zAxis)"
+                  "description": "Object chart configuration. Most important properties are:\n \n- chart `Object` with options regarding the chart area and plot area as well as general chart options.  \n   Detailed API for chart object is available in [API Site](http://api.highcharts.com/highcharts/chart)\n- credits `Object` with options regarding the chart area and plot area as well as general chart options.  \n   Detailed API for credits object is available in [API Site](http://api.highcharts.com/highcharts/credits)\n- labels `Object[]` with HTML labels that can be positioned anywhere in the chart area\n   Detailed API for labels object is available in [API Site](http://api.highcharts.com/highcharts/labels)\n- plotOptions `Object` wrapper for config objects for each series type.  \n   Detailed API for plotOptions object is available in [API Site](http://api.highcharts.com/highcharts/plotOptions)\n- series `Object[]` the actual series to append to the chart. \n   Detailed API for series object is available in [API Site](http://api.highcharts.com/highcharts/series)\n- subtitle `Object` the chart's subtitle.  \n   Detailed API for subtitle object is available in [API Site](http://api.highcharts.com/highcharts/subtitle)\n- title `Object` the chart's main title.\n   Detailed API for title object is available in [API Site](http://api.highcharts.com/highcharts/title)\n- tooltip `Object` Options for the tooltip that appears when the user hovers over a series or point.  \n   Detailed API for tooltip object is available in [API Site](http://api.highcharts.com/highcharts/tooltip)\n- xAxis `Object[]` The X axis or category axis. Normally this is the horizontal axis.  \n   Detailed API for xAxis object is available in [API Site](http://api.highcharts.com/highcharts/xAxis)\n- yAxis `Object[]` The Y axis or value axis. Normally this is the vertical axis.  \n   Detailed API for yAxis object is available in [API Site](http://api.highcharts.com/highcharts/yAxis)\n- zAxis `Object[]` The Z axis or depth axis for 3D plots.  \n   Detailed API for zAxis object is available in [API Site](http://api.highcharts.com/highcharts/zAxis)"
                 },
                 {
                   "name": "resetConfiguration",
@@ -2614,11 +2752,11 @@
               "privacy": "private",
               "sourceRange": {
                 "start": {
-                  "line": 260,
+                  "line": 268,
                   "column": 8
                 },
                 "end": {
-                  "line": 266,
+                  "line": 274,
                   "column": 9
                 }
               },
@@ -2635,11 +2773,11 @@
               "privacy": "private",
               "sourceRange": {
                 "start": {
-                  "line": 268,
+                  "line": 276,
                   "column": 8
                 },
                 "end": {
-                  "line": 281,
+                  "line": 289,
                   "column": 9
                 }
               },
@@ -2659,11 +2797,11 @@
               "privacy": "private",
               "sourceRange": {
                 "start": {
-                  "line": 283,
+                  "line": 291,
                   "column": 8
                 },
                 "end": {
-                  "line": 295,
+                  "line": 303,
                   "column": 9
                 }
               },
@@ -2717,11 +2855,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 759,
+                  "line": 775,
                   "column": 6
                 },
                 "end": {
-                  "line": 762,
+                  "line": 778,
                   "column": 7
                 }
               },
@@ -2746,11 +2884,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2394,
+                  "line": 2395,
                   "column": 6
                 },
                 "end": {
-                  "line": 2408,
+                  "line": 2409,
                   "column": 7
                 }
               },
@@ -2789,7 +2927,7 @@
                   "column": 6
                 },
                 "end": {
-                  "line": 291,
+                  "line": 294,
                   "column": 7
                 }
               },
@@ -2820,11 +2958,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2479,
+                  "line": 2482,
                   "column": 6
                 },
                 "end": {
-                  "line": 2489,
+                  "line": 2492,
                   "column": 7
                 }
               },
@@ -2859,11 +2997,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 329,
+                  "line": 332,
                   "column": 6
                 },
                 "end": {
-                  "line": 338,
+                  "line": 341,
                   "column": 7
                 }
               },
@@ -2898,11 +3036,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2427,
+                  "line": 2430,
                   "column": 6
                 },
                 "end": {
-                  "line": 2463,
+                  "line": 2466,
                   "column": 7
                 }
               },
@@ -2924,10 +3062,14 @@
                   "description": "Node metadata for current template node"
                 },
                 {
-                  "name": "name"
+                  "name": "name",
+                  "type": "string",
+                  "description": "Attribute name"
                 },
                 {
-                  "name": "value"
+                  "name": "value",
+                  "type": "string",
+                  "description": "Attribute value"
                 }
               ],
               "return": {
@@ -2943,11 +3085,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 384,
+                  "line": 387,
                   "column": 6
                 },
                 "end": {
-                  "line": 387,
+                  "line": 390,
                   "column": 7
                 }
               },
@@ -2986,16 +3128,16 @@
             },
             {
               "name": "addPropertyEffect",
-              "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n  {\n    fn: effectFunction, // Reference to function to call to perform effect\n    info: { ... }       // Effect metadata passed to function\n    trigger: {          // Optional triggering metadata; if not provided\n      name: string      // the property is treated as a wildcard\n      structured: boolean\n      wildcard: boolean\n    }\n  }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n  effectFunction(inst, path, props, oldProps, info, hasPaths)",
+              "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2123,
+                  "line": 2124,
                   "column": 6
                 },
                 "end": {
-                  "line": 2125,
+                  "line": 2126,
                   "column": 7
                 }
               },
@@ -3026,11 +3168,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 6
                 },
                 "end": {
-                  "line": 2138,
+                  "line": 2139,
                   "column": 7
                 }
               },
@@ -3056,16 +3198,16 @@
             },
             {
               "name": "createMethodObserver",
-              "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal Javascript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
+              "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2152,
+                  "line": 2153,
                   "column": 6
                 },
                 "end": {
-                  "line": 2154,
+                  "line": 2155,
                   "column": 7
                 }
               },
@@ -3091,11 +3233,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2163,
+                  "line": 2164,
                   "column": 6
                 },
                 "end": {
-                  "line": 2165,
+                  "line": 2166,
                   "column": 7
                 }
               },
@@ -3116,11 +3258,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2182,
+                  "line": 2183,
                   "column": 6
                 },
                 "end": {
-                  "line": 2184,
+                  "line": 2185,
                   "column": 7
                 }
               },
@@ -3146,11 +3288,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2193,
+                  "line": 2194,
                   "column": 6
                 },
                 "end": {
-                  "line": 2195,
+                  "line": 2196,
                   "column": 7
                 }
               },
@@ -3166,16 +3308,16 @@
             },
             {
               "name": "createComputedProperty",
-              "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal Javascript function signature:\n`'methodName(arg1, [..., argn])'`",
+              "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2210,
+                  "line": 2211,
                   "column": 6
                 },
                 "end": {
-                  "line": 2212,
+                  "line": 2213,
                   "column": 7
                 }
               },
@@ -3206,11 +3348,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2226,
+                  "line": 2227,
                   "column": 6
                 },
                 "end": {
-                  "line": 2228,
+                  "line": 2229,
                   "column": 7
                 }
               },
@@ -3235,11 +3377,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2291,
+                  "line": 2292,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -3270,11 +3412,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2524,
+                  "line": 2527,
                   "column": 6
                 },
                 "end": {
-                  "line": 2589,
+                  "line": 2592,
                   "column": 7
                 }
               },
@@ -3304,11 +3446,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2605,
+                  "line": 2608,
                   "column": 6
                 },
                 "end": {
-                  "line": 2622,
+                  "line": 2625,
                   "column": 7
                 }
               },
@@ -3380,11 +3522,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 153,
+              "line": 160,
               "column": 6
             },
             "end": {
-              "line": 296,
+              "line": 304,
               "column": 7
             }
           },
@@ -3394,14 +3536,14 @@
           "attributes": [
             {
               "name": "configuration",
-              "description": "Configuration object that exposes the JS Api to configure the chart.\n\nMost important methods are:\n- `addSeries (Object options, [Boolean redraw], [Mixed animation])`\n- `addAxis (Object options, [Boolean isX], [Boolean redraw], [Mixed animation])`\n- `setTitle (Object title, object subtitle, Boolean redraw)`\n\nMost important properties are:\n- `configuration.series`: An array of the chart's series. Detailed API for Series object is\n    available in [API Site](http://api.highcharts.com/highcharts/Series)\n- `configuration.xAxis`: An array of the chart's x axes. Detailed API for Axis object is\n    available in [API Site](http://api.highcharts.com/highcharts/Axis)\n- `configuration.yAxis`: An array of the chart's y axes. Detailed API for Axis object is\n    available in [API Site](http://api.highcharts.com/highcharts/Axis)\n- `configuration.title`: The chart title.\n\nFor detailed documentation of available API check the [API site](http://api.highcharts.com/highcharts/Chart)",
+              "description": "Configuration object that exposes the JS Api to configure the chart.\n\nMost important methods are:\n- `addSeries (Object options, [Boolean redraw], [Mixed animation])`\n- `addAxis (Object options, [Boolean isX], [Boolean redraw], [Mixed animation])`\n- `setTitle (Object title, object subtitle, Boolean redraw)`\n\nMost important properties are:\n- `configuration.series`: An array of the chart's series. Detailed API for Series object is\n    available in [API Site](http://api.highcharts.com/highcharts/series)\n- `configuration.xAxis`: An array of the chart's x axes. Detailed API for Axis object is\n    available in [API Site](http://api.highcharts.com/highcharts/xAxis)\n- `configuration.yAxis`: An array of the chart's y axes. Detailed API for Axis object is\n    available in [API Site](http://api.highcharts.com/highcharts/yAxis)\n- `configuration.title`: The chart title.\n\nFor detailed documentation of available API check the [API site](http://api.highcharts.com/highcharts/chart)",
               "sourceRange": {
                 "start": {
-                  "line": 181,
+                  "line": 188,
                   "column": 12
                 },
                 "end": {
-                  "line": 181,
+                  "line": 188,
                   "column": 33
                 }
               },

--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -28,7 +28,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
     }
 
     {
-
+      
       /**
        * `<vaadin-chart>` is a Polymer 2 element for creating high quality charts.
        *
@@ -60,8 +60,15 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
        * polymer serve --open
        * ```
        * Congratulations! You have your first Vaadin Chart setup.
+       *
+       * ### Basic use
        * 
-       * ### Configuring your chart using JS API 
+       * Now that we covered the basic steps to create an empty chart, let us show how you can configure it.
+       * 
+       * There are two ways of configuring your `<vaadin-chart>` element: **JS API** and **JSON API**.
+       * Note that you can make use of both APIs in your element.
+       * 
+       * #### Configuring your chart using JS API
        * 
        * Using as a base the project created with in Quick Start
        * 
@@ -97,7 +104,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
        * ```
        * 
        * 
-       * ### Configuring your chart using JS JSON API 
+       * #### Configuring your chart using JS JSON API
        * 
        * JS JSON API is a simple alternative to the JS API.
        * 
@@ -169,14 +176,14 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             *
             * Most important properties are:
             * - `configuration.series`: An array of the chart's series. Detailed API for Series object is
-            *     available in [API Site](http://api.highcharts.com/highcharts/Series)
+            *     available in [API Site](http://api.highcharts.com/highcharts/series)
             * - `configuration.xAxis`: An array of the chart's x axes. Detailed API for Axis object is
-            *     available in [API Site](http://api.highcharts.com/highcharts/Axis)
+            *     available in [API Site](http://api.highcharts.com/highcharts/xAxis)
             * - `configuration.yAxis`: An array of the chart's y axes. Detailed API for Axis object is
-            *     available in [API Site](http://api.highcharts.com/highcharts/Axis)
+            *     available in [API Site](http://api.highcharts.com/highcharts/yAxis)
             * - `configuration.title`: The chart title.
             * 
-            * For detailed documentation of available API check the [API site](http://api.highcharts.com/highcharts/Chart)
+            * For detailed documentation of available API check the [API site](http://api.highcharts.com/highcharts/chart)
             * @readonly
             */
             configuration: Object
@@ -192,6 +199,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           };
         }
 
+        /** @private */
         connectedCallback() {
           super.connectedCallback();
           this.configuration = Highcharts.chart(this.$.chart, this._baseConfig);
@@ -206,7 +214,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           this.shadowRoot.appendChild(licenseChecker);
         }
 
-        /*
+        /**
          * Update the chart configuration.
          * This JSON API provides a simple single-argument alternative to the configuration property.
          * 
@@ -220,7 +228,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
          *    Detailed API for labels object is available in [API Site](http://api.highcharts.com/highcharts/labels)
          * - plotOptions `Object` wrapper for config objects for each series type.  
          *    Detailed API for plotOptions object is available in [API Site](http://api.highcharts.com/highcharts/plotOptions)
-         * - series `Object[]` the actual series to append to the chart.  
+         * - series `Object[]` the actual series to append to the chart. 
          *    Detailed API for series object is available in [API Site](http://api.highcharts.com/highcharts/series)
          * - subtitle `Object` the chart's subtitle.  
          *    Detailed API for subtitle object is available in [API Site](http://api.highcharts.com/highcharts/subtitle)


### PR DESCRIPTION
- Make APIs doc one level lower
- Fix Highcharts API links
- Remove connectedCallback method from doc

Note that we are currently pointing to a newer version of Highcharts than we are using. This is due the fact that we still don't have our updated API doc site. We should update those links as soon we have a better option.

JIRA: CHARTS-590

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/201)
<!-- Reviewable:end -->
