### PR TITLE
Fix tooltip configuration

### DIFF
--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -212,8 +212,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             credits: {
               enabled: false
             },
-            // We found an issue (https://github.com/highcharts/highcharts/issues/7398) if no tooltip is set
-            // This is a workaround to make updating tooltip works
+            // Workaround for highcharts#7398 to make updating tooltip works
             tooltip: {
 
             },

--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -212,6 +212,11 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             credits: {
               enabled: false
             },
+            // We found an issue (https://github.com/highcharts/highcharts/issues/7398) if no tooltip is set
+            // This is a workaround to make updating tooltip works
+            tooltip: {
+
+            },
             exporting: {
               enabled: false
             },


### PR DESCRIPTION
Because no tooltip is set while creating a new Highcharts instance,
calling update with a new config doesn't work as expected.
I filled an issue on Highcharts about that.
https://github.com/highcharts/highcharts/issues/7398

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/223)
<!-- Reviewable:end -->
