### PR TITLE
Add accumulator for configuration object to prevent multiple draws

### DIFF
--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -385,12 +385,20 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
          *    if existing configuration should be discarded.
          */
         update(jsonConfiguration, resetConfiguration) {
+
+          this._jsonConfigurationBuffer = Object.assign({}, this._jsonConfigurationBuffer, jsonConfiguration);
+
           Polymer.RenderStatus.beforeNextRender(this, () => {
-            this.__inflateFunctions(jsonConfiguration);
+
+            if (!this._jsonConfigurationBuffer) {
+              return;
+            }
+
+            this.__inflateFunctions(this._jsonConfigurationBuffer);
 
             if (!this._dirty || resetConfiguration) {
               const initialOptions = Object.assign({}, this.options);
-              Object.assign(initialOptions, jsonConfiguration);
+              Object.assign(initialOptions, this._jsonConfigurationBuffer);
 
               if (this.timeline) {
                 this._configuration = Highcharts.stockChart(this.$.chart, initialOptions);
@@ -399,22 +407,24 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               }
 
               this._dirty = true;
+              this._jsonConfigurationBuffer = null;
               return;
             }
 
-            this.configuration.update(jsonConfiguration);
-            if (jsonConfiguration.credits) {
-              this.__updateOrAddCredits(jsonConfiguration.credits);
+            this.configuration.update(this._jsonConfigurationBuffer);
+            if (this._jsonConfigurationBuffer.credits) {
+              this.__updateOrAddCredits(this._jsonConfigurationBuffer.credits);
             }
-            if (jsonConfiguration.xAxis) {
-              this.__updateOrAddAxes(jsonConfiguration.xAxis, true);
+            if (this._jsonConfigurationBuffer.xAxis) {
+              this.__updateOrAddAxes(this._jsonConfigurationBuffer.xAxis, true);
             }
-            if (jsonConfiguration.yAxis) {
-              this.__updateOrAddAxes(jsonConfiguration.yAxis, false);
+            if (this._jsonConfigurationBuffer.yAxis) {
+              this.__updateOrAddAxes(this._jsonConfigurationBuffer.yAxis, false);
             }
-            if (jsonConfiguration.series) {
-              this.__updateOrAddSeries(jsonConfiguration.series);
+            if (this._jsonConfigurationBuffer.series) {
+              this.__updateOrAddSeries(this._jsonConfigurationBuffer.series);
             }
+            this._jsonConfigurationBuffer = null;            
           });
         }
 

--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -386,7 +386,10 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
          */
         update(jsonConfiguration, resetConfiguration) {
 
-          this._jsonConfigurationBuffer = Object.assign({}, this._jsonConfigurationBuffer, jsonConfiguration);
+          if (resetConfiguration || !this._jsonConfigurationBuffer) {
+            this._jsonConfigurationBuffer = {};
+          }
+          this._jsonConfigurationBuffer = Object.assign(this._jsonConfigurationBuffer, jsonConfiguration);
 
           Polymer.RenderStatus.beforeNextRender(this, () => {
 


### PR DESCRIPTION
`update` uses `Polymer.RenderStatus.beforeNextRender()` helper to enqueue the painting at `requestAnimationFrame` timing. But, when the tab is inactive, every task passed to `requestAnimationFrame` is delayed and they are only called once the tab is active again. 
This change is buffering the configuration in a way so that only the next render will use it and any other one after that can skip rendering the same configuration which was causing the tab to freeze sometimes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/230)
<!-- Reviewable:end -->
