### PR TITLE
Add test against iOS 11

### DIFF
--- a/wct.conf.js
+++ b/wct.conf.js
@@ -4,7 +4,7 @@ module.exports = {
   registerHooks: function(context) {
     var saucelabsPlatforms = [
       'macOS 10.12/iphone@10.3',
-      'macOS 10.12/ipad@10.3',
+      'macOS 10.12/ipad@11.0',
       'Windows 10/microsoftedge@15',
       'Windows 10/internet explorer@11',
       'macOS 10.12/safari@11.0'


### PR DESCRIPTION
iOS11 is supported by SauceLabs now. Updated one of the iOS devices to use it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/236)
<!-- Reviewable:end -->
