### PR TITLE
Remove default theme from style

### DIFF
--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -30,7 +30,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
 <dom-module id="vaadin-chart">
   <template>
-    <style include="vaadin-charts-default-theme">
+    <style>
       :host {
         display: block;
       }


### PR DESCRIPTION
`ThemableMixin` is responsible of adding the theme to the component, so it turns out that leaving `include="vaadin-charts-default-theme"` is causing it to have duplicated styles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/253)
<!-- Reviewable:end -->
