### PR TITLE
fix the name of the detault theme for the vaadin-chart element

### DIFF
--- a/test/style-test.html
+++ b/test/style-test.html
@@ -8,9 +8,9 @@
 </head>
 
 <body>
-  <dom-module id="vaadin-charts-custom-theme" theme-for="vaadin-chart">
+  <dom-module id="vaadin-chart-custom-theme" theme-for="vaadin-chart">
       <template>
-        <style include="vaadin-charts-default-theme">
+        <style include="vaadin-chart-default-theme">
           .highcharts-column-series rect.highcharts-point {
             stroke: rgb(255, 0, 0);
           }

--- a/vaadin-chart-default-theme.html
+++ b/vaadin-chart-default-theme.html
@@ -7,7 +7,7 @@ See the file LICENSE.md distributed with this software for more information abou
 See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete license.
 -->
 
-<dom-module id="vaadin-charts-default-theme" theme-for="vaadin-chart">
+<dom-module id="vaadin-chart-default-theme" theme-for="vaadin-chart">
     <template>
       <style>
 /* disable stylelint for highcharts css */

--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -14,7 +14,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 <link rel="import" href="../vaadin-license-checker/vaadin-license-checker.html">
 <link rel="import" href="../vaadin-element-mixin/vaadin-element-mixin.html">
 
-<link rel="import" href="vaadin-charts-default-theme.html">
+<link rel="import" href="vaadin-chart-default-theme.html">
 
 <script src="../highcharts/js/highstock.js"></script>
 <script src="../highcharts/js/highcharts-more.js"></script>


### PR DESCRIPTION
The Vaadin ThemableMixin would treat `vaadin-chartS-default-theme` as a custom theme for the `vaadin-chart` element. The default theme should be called `vaadin-chart-default-theme`. See [line 22](https://github.com/vaadin/vaadin-themable-mixin/blob/d6bb7cc0067fcacab132d65556e25903a0513098/vaadin-themable-mixin.html#L22) of the `Vaadin.ThemableMixin` definition for details.

When creating a custom theme for the `<vaadin-chart>` element it's ok to include `vaadin-chart-default-theme` if the custom theme is an extension of the default theme.
Related: https://github.com/vaadin/bakery-app-starter-flow-spring/pull/332

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/255)
<!-- Reviewable:end -->
