### PR TITLE
Add sudo:true to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 dist: trusty
 language: node_js
 node_js: 8.1


### PR DESCRIPTION
Travis is failing to run chrome-sandbox in non-sudo mode.

See https://github.com/vaadin/vaadin-element-skeleton/pull/90.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/260)
<!-- Reviewable:end -->
