### PR TITLE
Fix issue with component inserted in flex container

### DIFF
--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -34,6 +34,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
     <style>
       :host {
         display: block;
+        width: 100%;
       }
     </style>
     <div id="chart"></div>


### PR DESCRIPTION
Highcharts has an issue with flex container and shadow root, which
causes it to remove the chart container from the DOM tree.
This may be due the fact it can't properly calculate the size of
the chart container. Setting host width to 100% fixes this issue,
apparently.

JIRA: CHARTS-735

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/262)
<!-- Reviewable:end -->
