### PR TITLE
Prevent multiple calls to update from overriding configuration

### DIFF
--- a/test/element-dom-api-test.html
+++ b/test/element-dom-api-test.html
@@ -40,7 +40,7 @@
         setTimeout(() => {
           expect(vaadinChart.$.chart.querySelector('.highcharts-title > tspan').textContent).to.be.equal('Custom title');
           done();
-        }, 30);
+        }, 50);
       });
 
       it('should be able to add series', done => {

--- a/test/element-height-test.html
+++ b/test/element-height-test.html
@@ -52,8 +52,8 @@
             expect(300).to.be.equal(boundingClientRectContainer.height);
             expect(300).to.be.equal(element.configuration.chartHeight);
             done();
-          }, 50);
-        }, 10);
+          }, 60);
+        }, 20);
       });
 
     });

--- a/test/element-json-merge-test.html
+++ b/test/element-json-merge-test.html
@@ -1,0 +1,99 @@
+<!doctype html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>vaadin-chart tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../vaadin-chart.html">
+</head>
+
+<body>
+  <style>
+    vaadin-chart {
+      height: 200px;
+    }
+
+    vaadin-chart.expand-height {
+      height: 300px;
+    }
+  </style>
+  <test-fixture id="default">
+    <template>
+      <vaadin-chart>
+        <vaadin-chart-series data="[10,20,30]"></vaadin-chart-series>
+      </vaadin-chart>
+    </template>
+  </test-fixture>
+
+  <script>
+    describe('Configuration should not be lost', function() {
+      var element;
+
+      beforeEach(function() {
+        element = fixture('default');
+      });
+
+      it('should not lose configuration if called multiple times', function(done) {
+        element.update({
+          series: [
+            {
+              innerSize: 40
+            }
+          ]
+        });
+
+        element.update({
+          series: [
+            {
+              name: 'name of the series'
+            }
+          ]
+        });
+        setTimeout(() => {
+          expect(40).to.be.equal(element.configuration.series[0].options.innerSize);
+          expect('name of the series').to.be.equal(element.configuration.series[0].name);
+          done();
+        }, 20);
+      });
+
+      it('should handle merging multiple series', function(done) {
+        element.update({
+          series: [
+            {name: 'series 1'},
+            {name: 'series 2'}
+          ]
+        });
+        element.update({
+          series: [
+            null,
+            {innerSize: 100}
+          ]
+        });
+        setTimeout(() => {
+          const [firstSeries, secondSeries] = element.configuration.series;
+          expect('series 1').to.be.equal(firstSeries.name);
+          expect(100).to.be.equal(secondSeries.options.innerSize);
+          expect('series 2').to.be.equal(secondSeries.name);
+          done();
+        }, 20);
+      });
+
+      // it('chart height container should react to container change', done => {
+      //   setTimeout(() => {
+      //     // The class needs to be added after charts is first drawn
+      //     element.classList.add('expand-height');
+
+      //     // Then the test needs to wait for the component to react to new height
+      //     setTimeout(() => {
+      //       const boundingClientRectContainer = element.$.chart.getBoundingClientRect();
+
+      //       expect(300).to.be.equal(boundingClientRectContainer.height);
+      //       expect(300).to.be.equal(element.configuration.chartHeight);
+      //       done();
+      //     }, 50);
+      //   }, 10);
+      // });
+
+    });
+  </script>
+</body>

--- a/test/element-json-merge-test.html
+++ b/test/element-json-merge-test.html
@@ -79,23 +79,6 @@
           done();
         }, 70);
       });
-
-      // it('chart height container should react to container change', done => {
-      //   setTimeout(() => {
-      //     // The class needs to be added after charts is first drawn
-      //     element.classList.add('expand-height');
-
-      //     // Then the test needs to wait for the component to react to new height
-      //     setTimeout(() => {
-      //       const boundingClientRectContainer = element.$.chart.getBoundingClientRect();
-
-      //       expect(300).to.be.equal(boundingClientRectContainer.height);
-      //       expect(300).to.be.equal(element.configuration.chartHeight);
-      //       done();
-      //     }, 50);
-      //   }, 10);
-      // });
-
     });
   </script>
 </body>

--- a/test/element-json-merge-test.html
+++ b/test/element-json-merge-test.html
@@ -53,7 +53,7 @@
           expect(40).to.be.equal(element.configuration.series[0].options.innerSize);
           expect('name of the series').to.be.equal(element.configuration.series[0].name);
           done();
-        }, 20);
+        }, 70);
       });
 
       it('should handle merging multiple series', function(done) {
@@ -75,7 +75,7 @@
           expect(100).to.be.equal(secondSeries.options.innerSize);
           expect('series 2').to.be.equal(secondSeries.name);
           done();
-        }, 20);
+        }, 70);
       });
 
       // it('chart height container should react to container change', done => {

--- a/test/element-json-merge-test.html
+++ b/test/element-json-merge-test.html
@@ -70,7 +70,9 @@
           ]
         });
         setTimeout(() => {
-          const [firstSeries, secondSeries] = element.configuration.series;
+          const firstSeries = element.configuration.series[0];
+          const secondSeries = element.configuration.series[1];
+
           expect('series 1').to.be.equal(firstSeries.name);
           expect(100).to.be.equal(secondSeries.options.innerSize);
           expect('series 2').to.be.equal(secondSeries.name);

--- a/test/index.html
+++ b/test/index.html
@@ -24,7 +24,8 @@
       'js-api-chart-test.html',
       'js-json-api-chart-test.html',
       'js-private-api-chart-test.html',
-      'style-test.html'
+      'style-test.html',
+      'element-json-merge-test.html'
     ].reduce(function(suites, suite) {
       return suites.concat([suite, `${suite}?wc-shadydom=true`]);
     }, []));

--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -684,7 +684,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           if (resetConfiguration || !this._jsonConfigurationBuffer) {
             this._jsonConfigurationBuffer = {};
           }
-          this._jsonConfigurationBuffer = Object.assign(this._jsonConfigurationBuffer, jsonConfiguration);
+          this._jsonConfigurationBuffer = this.__makeConfigurationBuffer(this._jsonConfigurationBuffer, jsonConfiguration);
 
           Polymer.RenderStatus.beforeNextRender(this, () => {
 
@@ -718,6 +718,34 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             }
             this._jsonConfigurationBuffer = null;
           });
+        }
+
+        __makeConfigurationBuffer(target, source) {
+          const _source = Highcharts.merge(source);
+          const _target = Highcharts.merge(target);
+
+          this.__mergeConfigurationArray(_target, _source, 'series');
+          this.__mergeConfigurationArray(_target, _source, 'xAxis');
+          this.__mergeConfigurationArray(_target, _source, 'yAxis');
+
+          return Highcharts.merge(_target, _source);
+        }
+
+        __mergeConfigurationArray(target, configuration, entry) {
+          if (!configuration || !configuration[entry] || !Array.isArray(configuration[entry])) {
+            return;
+          }
+
+          if (!target[entry]) {
+            target[entry] = Array.from(configuration[entry]);
+            return;
+          }
+
+          const maxLength = Math.max(target[entry].length, configuration[entry].length);
+          for (let i = 0; i < maxLength; i++) {
+            target[entry][i] = Highcharts.merge(target[entry][i], configuration[entry][i]);
+          }
+          delete configuration[entry];
         }
 
         __inflateFunctions(jsonConfiguration) {


### PR DESCRIPTION
Previously the way to merge configurations was to use `Object.assign`. The issue with that approach is that for Arrays it only takes the newest one. This PR attempt to prevent it by merging the configurations object within arrays for `series`, `xAxis` and `yAxis`. 

JIRA: CHARTS-704

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/275)
<!-- Reviewable:end -->
