### PR TITLE
Fix order of module imports

### DIFF
--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -17,6 +17,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 <link rel="import" href="vaadin-chart-default-theme.html">
 
 <script src="../highcharts/js/highstock.js"></script>
+<!-- For some chart types, an error is raised if accessibility is added after highcharts-3d module -->
 <script src="../highcharts/js/modules/accessibility.js"></script>
 <script src="../highcharts/js/highcharts-more.js"></script>
 <script src="../highcharts/js/highcharts-3d.js"></script>

--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -17,9 +17,9 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 <link rel="import" href="vaadin-chart-default-theme.html">
 
 <script src="../highcharts/js/highstock.js"></script>
+<script src="../highcharts/js/modules/accessibility.js"></script>
 <script src="../highcharts/js/highcharts-more.js"></script>
 <script src="../highcharts/js/highcharts-3d.js"></script>
-<script src="../highcharts/js/modules/accessibility.js"></script>
 <script src="../highcharts/js/modules/data.js"></script>
 <script src="../highcharts/js/modules/drilldown.js"></script>
 <script src="../highcharts/js/modules/exporting.js"></script>


### PR DESCRIPTION
After adding `accessibility` module, some errors started to happen for some chart types. It seemed to be an unexpected error related with which order `accessibility` and `highcharts-3d` modules are imported. Importing `accessibility` module before fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/279)
<!-- Reviewable:end -->
