### PR TITLE
Avoid overriding highcharts default theme with theme customization

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -27,7 +27,8 @@
       'js-json-api-chart-test.html',
       'js-private-api-chart-test.html',
       'style-test.html',
-      'element-json-merge-test.html'
+      'element-json-merge-test.html',
+      'theme-test.html'
     ].reduce(function(suites, suite) {
       return suites.concat([suite, `${suite}?wc-shadydom=true`]);
     }, []));

--- a/test/theme-test.html
+++ b/test/theme-test.html
@@ -32,7 +32,8 @@
       it('data label connectors should have no fill', function(done) {
         setTimeout(function() {
           const connectors = Array.from(chart.querySelectorAll('.highcharts-data-label-connector'));
-          connectors.forEach(connector => expect(connector.fill).to.be.undefined);
+          expect(connectors).to.have.lengthOf(5);
+          connectors.forEach(connector => expect(window.getComputedStyle(connector).fill).to.equal('none'));
           done();
         }, 20);
       });

--- a/test/theme-test.html
+++ b/test/theme-test.html
@@ -1,0 +1,43 @@
+<!doctype html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>vaadin-chart tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../vaadin-chart.html">
+</head>
+
+<body>
+  <test-fixture id="pie-with-labels">
+    <template>
+      <vaadin-chart id="mychart" title="Custom Title" subtitle="Custom Subtitle">
+        <vaadin-chart-series type="pie" title="Tokyo" values="[19,12,9,24,5]" value-labels='["Mon", "Tue", "Wed", "Thur", "Fri"]'></vaadin-chart-series>
+      </vaadin-chart>
+    </template>
+  </test-fixture>
+
+  <script>
+    describe('Test defaults in theme', function() {
+      var chart;
+
+      beforeEach(done => {
+        chart = fixture('pie-with-labels').$.chart;
+        Polymer.flush();
+        setTimeout(() => {
+          done();
+        }, 100);
+      });
+
+
+      it('data label connectors should have no fill', function(done) {
+        setTimeout(function() {
+          const connectors = Array.from(chart.querySelectorAll('.highcharts-data-label-connector'));
+          connectors.forEach(connector => expect(connector.fill).to.be.undefined);
+          done();
+        }, 20);
+      });
+      
+
+    });
+  </script>
+</body>

--- a/vaadin-chart-default-theme.html
+++ b/vaadin-chart-default-theme.html
@@ -10,6 +10,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 <dom-module id="vaadin-chart-default-theme" theme-for="vaadin-chart">
     <template>
       <style>
+/* When updating this file do not override vaadin-charts custom properties section */
 /* disable stylelint for highcharts css */
 /* stylelint-disable */
 /**
@@ -213,55 +214,57 @@ g.highcharts-series,
 
 /* Series options */
 /* Default colors */
+/* vaadin-charts custom properties */
 .highcharts-color-0 {
-  fill: #7cb5ec;
-  stroke: #7cb5ec;
+  fill: var(--vaadin-charts-color-0, #7cb5ec);
+  stroke: var(--vaadin-charts-color-0, #7cb5ec);
 }
 
 .highcharts-color-1 {
-  fill: #434348;
-  stroke: #434348;
+  fill: var(--vaadin-charts-color-1, #434348);
+  stroke: var(--vaadin-charts-color-1, #434348);
 }
 
 .highcharts-color-2 {
-  fill: #90ed7d;
-  stroke: #90ed7d;
+  fill: var(--vaadin-charts-color-2, #90ed7d);
+  stroke: var(--vaadin-charts-color-2, #90ed7d);
 }
 
 .highcharts-color-3 {
-  fill: #f7a35c;
-  stroke: #f7a35c;
+  fill: var(--vaadin-charts-color-3, #f7a35c);
+  stroke: var(--vaadin-charts-color-3, #f7a35c);
 }
 
 .highcharts-color-4 {
-  fill: #8085e9;
-  stroke: #8085e9;
+  fill: var(--vaadin-charts-color-4, #8085e9);
+  stroke: var(--vaadin-charts-color-4, #8085e9);
 }
 
 .highcharts-color-5 {
-  fill: #f15c80;
-  stroke: #f15c80;
+  fill: var(--vaadin-charts-color-5, #f15c80);
+  stroke: var(--vaadin-charts-color-5, #f15c80);
 }
 
 .highcharts-color-6 {
-  fill: #e4d354;
-  stroke: #e4d354;
+  fill: var(--vaadin-charts-color-6, #e4d354);
+  stroke: var(--vaadin-charts-color-6, #e4d354);
 }
 
 .highcharts-color-7 {
-  fill: #2b908f;
-  stroke: #2b908f;
+  fill: var(--vaadin-charts-color-7, #2b908f);
+  stroke: var(--vaadin-charts-color-7, #2b908f);
 }
 
 .highcharts-color-8 {
-  fill: #f45b5b;
-  stroke: #f45b5b;
+  fill: var(--vaadin-charts-color-8, #f45b5b);
+  stroke: var(--vaadin-charts-color-8, #f45b5b);
 }
 
 .highcharts-color-9 {
-  fill: #91e8e1;
-  stroke: #91e8e1;
+  fill: var(--vaadin-charts-color-9, #91e8e1);
+  stroke: var(--vaadin-charts-color-9, #91e8e1);
 }
+/* end of vaadin-charts custom properties */
 
 .highcharts-area {
   fill-opacity: 0.75;
@@ -821,56 +824,8 @@ text.highcharts-drilldown-data-label,
   stroke: #333333;
 }
 
-/* vaadin-charts custom properties */
-.highcharts-color-0 {
-  fill: var(--vaadin-charts-color-0, #7cb5ec);
-  stroke: var(--vaadin-charts-color-0, #7cb5ec);
-}
 
-.highcharts-color-1 {
-  fill: var(--vaadin-charts-color-1, #434348);
-  stroke: var(--vaadin-charts-color-1, #434348);
-}
 
-.highcharts-color-2 {
-  fill: var(--vaadin-charts-color-2, #90ed7d);
-  stroke: var(--vaadin-charts-color-2, #90ed7d);
-}
-
-.highcharts-color-3 {
-  fill: var(--vaadin-charts-color-3, #f7a35c);
-  stroke: var(--vaadin-charts-color-3, #f7a35c);
-}
-
-.highcharts-color-4 {
-  fill: var(--vaadin-charts-color-4, #8085e9);
-  stroke: var(--vaadin-charts-color-4, #8085e9);
-}
-
-.highcharts-color-5 {
-  fill: var(--vaadin-charts-color-5, #f15c80);
-  stroke: var(--vaadin-charts-color-5, #f15c80);
-}
-
-.highcharts-color-6 {
-  fill: var(--vaadin-charts-color-6, #e4d354);
-  stroke: var(--vaadin-charts-color-6, #e4d354);
-}
-
-.highcharts-color-7 {
-  fill: var(--vaadin-charts-color-7, #2b908f);
-  stroke: var(--vaadin-charts-color-7, #2b908f);
-}
-
-.highcharts-color-8 {
-  fill: var(--vaadin-charts-color-8, #f45b5b);
-  stroke: var(--vaadin-charts-color-8, #f45b5b);
-}
-
-.highcharts-color-9 {
-  fill: var(--vaadin-charts-color-9, #91e8e1);
-  stroke: var(--vaadin-charts-color-9, #91e8e1);
-}
 
 /* stylelint-enable */
     </style>


### PR DESCRIPTION
Moved classes with custom css properties to their original location in Highcharts theme

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/307)
<!-- Reviewable:end -->
