### PR TITLE
Use camelCase for property names

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -43,7 +43,7 @@
               "defaultValue": "[]"
             },
             {
-              "name": "value-labels",
+              "name": "valueLabels",
               "type": "ChartLabelsMapper",
               "description": "Labels for the series values. Acceptable input are:\n- An array e.g `'[\"Mon\", \"Tue\", \"Wed\", \"Thur\", \"Fri\"]'`. This maps to corresponding values by position.\n- A mapping object e.g `'{10: \"Mon\", 20: \"Tue\", 30: \"Wed\"}'`. This maps to specific values.\n- A function e.g `'e => e + \"km\"'`. This is evaluated against every value to generate its label.\n\nAny data point not covered (e.g value not present in the mapping object\nor mapping array shorter than the list of values), results in the actual value being used as the label.",
               "privacy": "public",
@@ -64,7 +64,7 @@
             {
               "name": "__labelsMapper",
               "type": "ChartLabelsMapper",
-              "description": "Internal value-labels representation so that the original property/attribute set\non value-labels can be preserved.",
+              "description": "Internal valueLabels representation so that the original property/attribute set\non valueLabels can be preserved.",
               "privacy": "private",
               "sourceRange": {
                 "start": {
@@ -623,9 +623,9 @@
               }
             },
             {
-              "name": "no-legend",
+              "name": "noLegend",
               "type": "boolean",
-              "description": "Specifies whether to hide legend or show.\nLegend configuration can be set up via additional-options property",
+              "description": "Specifies whether to hide legend or show.\nLegend configuration can be set up via additionalOptions property",
               "privacy": "public",
               "sourceRange": {
                 "start": {
@@ -726,7 +726,7 @@
               }
             },
             {
-              "name": "additional-options",
+              "name": "additionalOptions",
               "type": "Object",
               "description": "Represents additional JSON configuration.",
               "privacy": "public",
@@ -1686,7 +1686,7 @@
             },
             {
               "name": "no-legend",
-              "description": "Specifies whether to hide legend or show.\nLegend configuration can be set up via additional-options property",
+              "description": "Specifies whether to hide legend or show.\nLegend configuration can be set up via additionalOptions property",
               "sourceRange": {
                 "start": {
                   "line": 316,

--- a/analysis.json
+++ b/analysis.json
@@ -594,7 +594,7 @@
                 },
                 "end": {
                   "line": 299,
-                  "column": 35
+                  "column": 33
                 }
               },
               "metadata": {
@@ -1662,7 +1662,7 @@
                 },
                 "end": {
                   "line": 299,
-                  "column": 35
+                  "column": 33
                 }
               },
               "metadata": {},

--- a/test/element-api-chart-test.html
+++ b/test/element-api-chart-test.html
@@ -56,8 +56,8 @@
         expect(element.$.chart.querySelector('.highcharts-title > tspan').textContent).to.be.equal('My title');
       });
 
-      it('should react to additional-options object change', done => {
-        element['additional-options'] = {title: {text: 'Updated title'}};
+      it('should react to additionalOptions object change', done => {
+        element.additionalOptions = {title: {text: 'Updated title'}};
 
         setTimeout(() => {
           expect(element.$.chart.querySelector('.highcharts-title > tspan').textContent).to.be.equal('Updated title');
@@ -65,8 +65,8 @@
         }, 100);
       });
 
-      it('should react to additional-options subproperty change', done => {
-        element.set('additional-options.title.text', 'Reindeer statistics');
+      it('should react to additionalOptions subproperty change', done => {
+        element.set('additionalOptions.title.text', 'Reindeer statistics');
 
         setTimeout(() => {
           expect(element.$.chart.querySelector('.highcharts-title > tspan').textContent).to.be.equal('Reindeer statistics');

--- a/vaadin-chart-series.html
+++ b/vaadin-chart-series.html
@@ -119,7 +119,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              * to mutate the values array in order to make the component aware of the
              * change and be able to synchronize it.
              */
-            'values': {
+            values: {
               type: Array,
               value: () => []
             },
@@ -133,7 +133,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              * Any data point not covered (e.g value not present in the mapping object
              * or mapping array shorter than the list of values), results in the actual value being used as the label.
              */
-            'valueLabels': {
+            valueLabels: {
               type: ChartLabelsMapper,
               reflectToAttribute: true
             },
@@ -142,7 +142,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              * Internal valueLabels representation so that the original property/attribute set
              * on valueLabels can be preserved.
              */
-            '__labelsMapper': {
+            __labelsMapper: {
               type: ChartLabelsMapper,
               value: () => new ChartLabelsMapper([])
             },
@@ -152,7 +152,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              *  Defaults to `'line'` in case no type is set for the chart.
              * Note that `'bar'`, `'gauge'` and `'solidgauge'` should be set as default series type on `<vaadin-chart>`.
              */
-            'type': {
+            type: {
               type: String,
               observer: '__typeObserver',
               reflectToAttribute: true
@@ -161,7 +161,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             /**
              * The name of the series as shown in the legend, tooltip etc.
              */
-            'title': {
+            title: {
               type: String,
               observer: '__titleObserver',
               reflectToAttribute: true
@@ -174,7 +174,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              *  - `hidden`: markers are always hidden
              *  - `auto`: markers are visible for widespread data and hidden, when data is dense *(default)*
              */
-            'markers': {
+            markers: {
               type: String,
               observer: '__markersObserver',
               reflectToAttribute: true
@@ -184,7 +184,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              * Displayed as a title for the axis.
              * If no unit is defined, then series will be connected to the first axis.
              */
-            'unit': {
+            unit: {
               type: 'String',
               observer: '__unitObserver',
               reflectToAttribute: true
@@ -195,7 +195,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              *
              * @readonly
              */
-            'options': {
+            options: {
               type: Object
             }
           };

--- a/vaadin-chart-series.html
+++ b/vaadin-chart-series.html
@@ -133,14 +133,14 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              * Any data point not covered (e.g value not present in the mapping object
              * or mapping array shorter than the list of values), results in the actual value being used as the label.
              */
-            'value-labels': {
+            'valueLabels': {
               type: ChartLabelsMapper,
               reflectToAttribute: true
             },
 
             /*
-             * Internal value-labels representation so that the original property/attribute set
-             * on value-labels can be preserved.
+             * Internal valueLabels representation so that the original property/attribute set
+             * on valueLabels can be preserved.
              */
             '__labelsMapper': {
               type: ChartLabelsMapper,
@@ -204,7 +204,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         static get observers() {
           return [
             '__valuesObserver(values.splices)',
-            '__labelsObserver(value-labels.*, values)'
+            '__labelsObserver(valueLabels.*, values)'
           ];
         }
 
@@ -251,7 +251,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         }
 
         __labelsObserver(changeRecord, values) {
-          const currentLabels = this['value-labels'] || [];
+          const currentLabels = this.valueLabels || [];
           if (currentLabels instanceof ChartLabelsMapper) {
             this.__labelsMapper = currentLabels;
           } else {

--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -312,9 +312,9 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
             /**
              * Specifies whether to hide legend or show.
-             * Legend configuration can be set up via additional-options property
+             * Legend configuration can be set up via additionalOptions property
              */
-            'no-legend': {
+            'noLegend': {
               type: Boolean,
               observer: '__hideLegend',
               reflectToAttribute: true
@@ -359,7 +359,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             /**
              * Represents additional JSON configuration.
              */
-            'additional-options': {
+            'additionalOptions': {
               type: Object,
               reflectToAttribute: true
             }
@@ -368,7 +368,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
         static get observers() {
           return [
-            '__updateAdditionalOptions(additional-options.*)'
+            '__updateAdditionalOptions(additionalOptions.*)'
           ];
         }
 
@@ -422,7 +422,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
         get options() {
           const options = Object.assign({}, this._baseConfig);
-          this.__deepMerge(options, this['additional-options']);
+          this.__deepMerge(options, this.additionalOptions);
 
           if (this.type) {
             options.chart = options.chart || {};
@@ -447,7 +447,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             }];
           }
 
-          if (this['no-legend']) {
+          if (this.noLegend) {
             options.legend = {
               enabled: false
             };
@@ -1143,7 +1143,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
         __updateAdditionalOptions() {
           if (this.configuration) {
-            this.update(this['additional-options']);
+            this.update(this.additionalOptions);
           }
         }
 

--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -297,14 +297,14 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              * @public
              * @type {Object}
              */
-            'configuration': Object,
+            configuration: Object,
 
             /**
              * If categories are present names are used instead of numbers for the category axis.
              * The format of categories can be an `Array` with a list of categories, such as `['2010', '2011', '2012']`
              * or a mapping `Object`, like `{0:'1',9:'Target (10)', 15: 'Max'}`.
              */
-            'categories': {
+            categories: {
               type: Object,
               reflectToAttribute: true,
               observer: '__updateCategories'
@@ -314,7 +314,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              * Specifies whether to hide legend or show.
              * Legend configuration can be set up via additionalOptions property
              */
-            'noLegend': {
+            noLegend: {
               type: Boolean,
               observer: '__hideLegend',
               reflectToAttribute: true
@@ -323,7 +323,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             /**
              * Specifies whether the chart is a normal chart or a timeline chart.
              */
-            'timeline': {
+            timeline: {
               type: Boolean,
               reflectToAttribute: true
             },
@@ -331,7 +331,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             /**
              * Represents the title of the chart.
              */
-            'title': {
+            title: {
               type: String,
               observer: '__updateTitle',
               reflectToAttribute: true
@@ -341,7 +341,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              * Sets the default series type of the chart.
              * Note that `'bar'`, `'gauge'` and `'solidgauge'` should be set as default series type.
              */
-            'type': {
+            type: {
               type: String,
               observer: '__updateType',
               reflectToAttribute: true
@@ -350,7 +350,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             /**
              * Represents the subtitle of the chart.
              */
-            'subtitle': {
+            subtitle: {
               type: String,
               observer: '__updateSubtitle',
               reflectToAttribute: true
@@ -359,7 +359,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             /**
              * Represents additional JSON configuration.
              */
-            'additionalOptions': {
+            additionalOptions: {
               type: Object,
               reflectToAttribute: true
             }


### PR DESCRIPTION
From polymer docs:
Attribute names with dashes are converted to camelCase property
names by capitalizing the character following each dash, then
removing the dashes.
For example, the attribute first-name maps to firstName.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/326)
<!-- Reviewable:end -->
