### PR TITLE
Do not dispatch axis event if axis data is not available

### DIFF
--- a/test/element-events-test.html
+++ b/test/element-events-test.html
@@ -161,6 +161,18 @@
         timelineChart.addEventListener('yaxes-extremes-set', setExtremesListener);
         timelineChart.configuration.yAxis[0].setExtremes(minExtreme, maxExtreme);
       });
+
+      it('should not trigger axis event if axis is hidden by action', done => {
+        const axisResizeSpy = sinon.spy(); 
+        chart.addEventListener('yaxes-extremes-set', axisResizeSpy);
+        chart.configuration.series[0].setVisible(false);
+        setTimeout(() => {
+          expect(axisResizeSpy.called).to.be.false;
+          chart.removeEventListener('chart-redraw', axisResizeSpy);
+          chart.configuration.series[0].setVisible(true);
+          done();
+        });
+      });
     });
   </script>
 </body>

--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -1066,6 +1066,11 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
                   }
                 };
 
+                if (event.type === 'afterSetExtremes') {
+                  if (!event.min || !event.max) {
+                    return;
+                  }
+                }
                 // Workaround for vaadin-charts-flow because of https://github.com/vaadin/flow/issues/3102
                 if (event.type === 'selection') {
                   if (event.xAxis && event.xAxis[0]) {


### PR DESCRIPTION
Axis afterSetExtremes is meaningless if axis is not defined.
Also helps prevent flow#3102
Fixes CHARTS-778
Cherry-pick from #337