### PR TITLE
Avoid setting width attribute when SVG element cannot be measured in pixels

### DIFF
--- a/chart-svg-element-empty-width-attribute.js
+++ b/chart-svg-element-empty-width-attribute.js
@@ -1,0 +1,32 @@
+(function() {
+  if (Highcharts) {
+    // Workaround for https://github.com/vaadin/vaadin-charts/issues/294
+    Highcharts.SVGElement.prototype.strokeWidth = function () {
+      var val = this.getStyle('stroke-width'),
+        ret,
+        dummy;
+
+      // Read pixel values directly
+      if (val.indexOf('px') === val.length - 2) {
+        ret = Highcharts.pInt(val);
+
+        // Other values like em, pt etc need to be measured
+      } else {
+        dummy = Highcharts.doc.createElementNS(Highcharts.SVGElement.prototype.SVG_NS, 'rect');
+
+        const attributes = {
+          'stroke-width': 0
+        };
+        if (val) {
+          attributes.width = val;
+        }
+
+        this.attr(dummy, attributes);
+        this.element.parentNode.appendChild(dummy);
+        ret = dummy.getBBox().width;
+        dummy.parentNode.removeChild(dummy);
+      }
+      return ret;
+    };
+  }
+})();

--- a/chart-svg-element-empty-width-attribute.js
+++ b/chart-svg-element-empty-width-attribute.js
@@ -1,7 +1,7 @@
 (function() {
   if (Highcharts) {
     // Workaround for https://github.com/vaadin/vaadin-charts/issues/294
-    Highcharts.SVGElement.prototype.strokeWidth = function () {
+    Highcharts.SVGElement.prototype.strokeWidth = function() {
       var val = this.getStyle('stroke-width'),
         ret,
         dummy;

--- a/vaadin-chart.html
+++ b/vaadin-chart.html
@@ -28,8 +28,9 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 <script src="../highcharts/js/modules/heatmap.js"></script>
 <script src="../highcharts/js/modules/solid-gauge.js"></script>
 <script src="../highcharts/js/modules/treemap.js"></script>
-<script src="chart-temporary-display.js"></script>
 <script src="chart-deep-merger.js"></script>
+<script src="chart-svg-element-empty-width-attribute.js"></script>
+<script src="chart-temporary-display.js"></script>
 
 <link rel="import" href="vaadin-chart-series.html">
 


### PR DESCRIPTION
Fixes #294

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/343)
<!-- Reviewable:end -->
