### PR TITLE
Test if IE/Edge on series disconnectedCallback

### DIFF
--- a/src/vaadin-chart-series.html
+++ b/src/vaadin-chart-series.html
@@ -266,7 +266,11 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         /** @private */
         disconnectedCallback() {
           super.disconnectedCallback();
-          if (this.__hasSeriesConfig() && !this.parentNode) {
+
+          // IE/Edge has parentNode not null even when node is removed from parent
+          const isIEorEdge = /(Trident|Edge)/.test(navigator.userAgent);
+
+          if (this.__hasSeriesConfig() && (!this.parentNode || isIEorEdge)) {
             this._series.remove();
           }
         }

--- a/test/element-api-chart-test.html
+++ b/test/element-api-chart-test.html
@@ -264,7 +264,7 @@
             expect(chart.configuration.is3d()).to.be.true;
 
             // Track regression https://github.com/highcharts/highcharts/issues/8555
-            const rendered = chart.$.chart.querySelector('.highcharts-series-0').children.length > 0;
+            const rendered = chart.$.chart.querySelector('.highcharts-series-0').hasChildNodes();
             expect(rendered).to.be.true;
             chart.chart3d = false;
             done();


### PR DESCRIPTION
- IE/Edge has parentNode not null even when the node is removed from its parent. This change checks either if parentNode is not present or if the browser is IE or Edge in order to call `this._series.remove()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/439)
<!-- Reviewable:end -->
