### PR TITLE
Remove version checks to align with skeleton

### DIFF
--- a/src/vaadin-chart-series.html
+++ b/src/vaadin-chart-series.html
@@ -11,10 +11,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
 <dom-module id="vaadin-chart-series">
   <script>
-    if (!Polymer.Element) {
-      throw new Error(`Unexpected Polymer version ${Polymer.version} is used, expected v2.0.0 or later.`);
-    }
-
     (() => {
       /**
        * `<vaadin-chart-series>` is a custom element for creating series for Vaadin Charts.

--- a/src/vaadin-chart.html
+++ b/src/vaadin-chart.html
@@ -68,10 +68,6 @@ MAGI ADD END -->
   </template>
 
   <script>
-    if (!Polymer.Element) {
-      throw new Error(`Unexpected Polymer version ${Polymer.version} is used, expected v2.0.0 or later.`);
-    }
-
     (() => {
       /**
        * `<vaadin-chart>` is a Web Component for creating high quality charts.


### PR DESCRIPTION
We no longer use these checks anywhere but here in charts. 
Also, some customer complained about this error incorrectly thrown in IE11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/447)
<!-- Reviewable:end -->
