### PR TITLE
refactor: only run license checker when needed

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -1,0 +1,7 @@
+{
+  "lint": {
+    "warningsToIgnore": [
+      "multiple-global-declarations"
+    ]
+  }
+}

--- a/src/vaadin-chart.html
+++ b/src/vaadin-chart.html
@@ -508,6 +508,19 @@ MAGI ADD END -->
           ];
         }
 
+        /**
+         * @protected
+         */
+        static _finalizeClass() {
+          super._finalizeClass();
+
+          const devModeCallback = window.Vaadin.developmentModeCallback;
+          const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
+          if (typeof licenseChecker === 'function') {
+            licenseChecker(ChartElement);
+          }
+        }
+
         constructor() {
           super();
 
@@ -1747,12 +1760,6 @@ MAGI ADD END -->
        * @namespace Vaadin
        */
       window.Vaadin.ChartElement = ChartElement;
-
-      const licenseChecker = window.Vaadin.developmentModeCallback
-        && window.Vaadin.developmentModeCallback['vaadin-license-checker'];
-      if (typeof licenseChecker === 'function') {
-        licenseChecker(ChartElement);
-      }
     })();
   </script>
 </dom-module>


### PR DESCRIPTION
Connected to vaadin/components-team-tasks#492

This PR makes sure the license checker is only called when the component is created.
The static `_finalizeClass` method is needed to ensure we call it [once per class](https://github.com/Polymer/polymer/blob/f6ccc9d1bdc81e934e21bf27b3dba517b5840fd4/lib/mixins/properties-mixin.js#L138-L147).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts/461)
<!-- Reviewable:end -->
