### PR TITLE
feat: prepare for TS defs generation

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,0 +1,26 @@
+import { PointOptionsObject, SeriesOptionsType } from 'highcharts';
+
+export type ChartCategories = Array<string> | { [key: number]: string };
+
+export type ChartCategoryPosition = 'left' | 'right' | 'top' | 'bottom';
+
+export type ChartSeriesMarkers = 'shown' | 'hidden' | 'auto';
+
+export interface ChartSeriesConfig {
+  data?: ChartSeriesValues;
+  marker?: { enabled: boolean | null }
+  name?: string;
+  neckWidth?: number | string;
+  neckHeight?: number | string;
+  stack?: number | string;
+  type?: string;
+  yAxis?: string;
+  yAxisValueMin?: number;
+  yAxisValueMax?: number;
+}
+
+export type ChartSeriesOptions = ChartSeriesConfig & SeriesOptionsType;
+
+export type ChartSeriesValues = Array<number|Array<number>|PointOptionsObject>;
+
+export type ChartStacking = 'normal' | 'percent' | null;

--- a/bower.json
+++ b/bower.json
@@ -34,9 +34,9 @@
   "dependencies": {
     "highcharts": "8.1.0",
     "polymer": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.5.2",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
     "vaadin-license-checker": "vaadin/license-checker#^2.1.0",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.2"
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",

--- a/chart-deep-merger.js
+++ b/chart-deep-merger.js
@@ -6,29 +6,24 @@ window.Vaadin = window.Vaadin || {};
  * @namespace Vaadin.Charts
  */
 Vaadin.Charts = Vaadin.Charts || {};
-/** @private */
-// eslint-disable-next-line no-unused-vars
-Vaadin.Charts.ChartDeepMerger = (() => class {
 
-  static __isObject(item) {
-    return (item && typeof item === 'object' && !Array.isArray(item));
-  }
+/** @protected */
+Vaadin.Charts.deepMerge = function deepMerge(target, source) {
+  const isObject = item => (item && typeof item === 'object' && !Array.isArray(item));
 
-  static __deepMerge(target, source) {
-    if (this.__isObject(source) && this.__isObject(target)) {
-      for (const key in source) {
-        if (this.__isObject(source[key])) {
-          if (!target[key]) {
-            Object.assign(target, {[key]: {}});
-          }
-
-          this.__deepMerge(target[key], source[key]);
-        } else {
-          Object.assign(target, {[key]: source[key]});
+  if (isObject(source) && isObject(target)) {
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key]) {
+          Object.assign(target, {[key]: {}});
         }
+
+        deepMerge(target[key], source[key]);
+      } else {
+        Object.assign(target, {[key]: source[key]});
       }
     }
-
-    return target;
   }
-})();
+
+  return target;
+};

--- a/chart-deep-merger.js
+++ b/chart-deep-merger.js
@@ -7,7 +7,7 @@ window.Vaadin = window.Vaadin || {};
  */
 Vaadin.Charts = Vaadin.Charts || {};
 
-/** @protected */
+/** @private */
 Vaadin.Charts.deepMerge = function deepMerge(target, source) {
   const isObject = item => (item && typeof item === 'object' && !Array.isArray(item));
 

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -9,6 +9,7 @@
   ],
   "autoImport": {
     "highcharts": [
+      "Axis",
       "Chart",
       "Options",
       "PointOptionsObject",

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,27 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "vaadin-chart-default-theme.js",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ],
+  "autoImport": {
+    "highcharts": [
+      "Chart",
+      "Options",
+      "PointOptionsObject",
+      "Series",
+      "SeriesOptionsType"
+    ],
+    "./@types/interfaces": [
+      "ChartCategories",
+      "ChartCategoryPosition",
+      "ChartSeriesMarkers",
+      "ChartSeriesOptions",
+      "ChartSeriesValues",
+      "ChartStacking"
+    ]
+  }
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -2,7 +2,8 @@ module.exports = {
   files: [
     'src/vaadin-chart.js',
     'theme/vaadin-chart-default-theme.js',
-    'test/exporting-test.html'
+    'test/exporting-test.html',
+    'vaadin-chart.js'
   ],
 
   from: [
@@ -18,7 +19,9 @@ module.exports = {
     '  then delete this comment!\n' +
     '*/',
 
-    /import '..\/vaadin-chart.js';/g
+    /import '..\/vaadin-chart.js';/g,
+
+    /import '\.\/src\/vaadin-(.+)\.js';/
   ],
 
   to: [
@@ -35,6 +38,8 @@ module.exports = {
     ``,
 
     `import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
-     import '../vaadin-chart.js';`
+     import '../vaadin-chart.js';`,
+
+    `import './src/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
   ]
 };

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,6 +1,7 @@
 module.exports = {
   files: [
     'src/vaadin-chart.js',
+    'src/vaadin-chart-series.js',
     'theme/vaadin-chart-default-theme.js',
     'test/exporting-test.html',
     'vaadin-chart.js'
@@ -21,7 +22,9 @@ module.exports = {
 
     /import '..\/vaadin-chart.js';/g,
 
-    /import '\.\/src\/vaadin-(.+)\.js';/
+    /import '\.\/src\/vaadin-(.+)\.js';/,
+
+    'class ChartSeriesElement extends (class extends PolymerElement {}) {'
   ],
 
   to: [
@@ -40,6 +43,8 @@ module.exports = {
     `import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
      import '../vaadin-chart.js';`,
 
-    `import './src/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+    `import './src/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`,
+
+    'class ChartSeriesElement extends PolymerElement {'
   ]
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "homepage": "https://vaadin.com/charts",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
+    "@types",
     "src",
     "theme"
   ],

--- a/src/vaadin-chart-series.html
+++ b/src/vaadin-chart-series.html
@@ -55,9 +55,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
        *  chart.removeChild(seriesToBeRemoved);
        * ```
        *
-       * @polymer
-       * @customElement
-       * @extends {Polymer.Element}
        * @memberof Vaadin
        * @demo demo/index.html
        */
@@ -69,7 +66,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         get options() {
           // Should be {}, workaround for https://github.com/highcharts/highcharts/issues/13482
           const baseConfig = {accessibility: {enabled: false}};
-          const options = Vaadin.Charts.ChartDeepMerger.__deepMerge(baseConfig, this.additionalOptions);
+          const options = Vaadin.Charts.deepMerge(baseConfig, this.additionalOptions);
 
           if (this.type) {
             options.type = this.type;
@@ -131,6 +128,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              * Note that you should always use [Polymer API](https://www.polymer-project.org/2.0/docs/devguide/model-data#array-mutation)
              * to mutate the values array in order to make the component aware of the
              * change and be able to synchronize it.
+             * @type {ChartSeriesValues}
              */
             values: {
               type: Array,
@@ -138,10 +136,11 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             },
 
             /**
-             *  Value-axis minimum-value.
-             *  Sets the value to a series bound by 'unit' property.
-             *  Otherwise sets the value to the first series.
-             *  Undefined by default (determined from data).
+             * Value-axis minimum-value.
+             * Sets the value to a series bound by 'unit' property.
+             * Otherwise sets the value to the first series.
+             * Undefined by default (determined from data).
+             * @type {number | null}
              */
             valueMin: {
               type: Number,
@@ -149,8 +148,9 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             },
 
             /**
-             *  Value-axis maximum-value.
-             *  See the 'valueMin'
+             * Value-axis maximum-value.
+             * See the 'valueMin'
+             * @type {number | null}
              */
             valueMax: {
               type: Number,
@@ -158,8 +158,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             },
 
             /**
-             *  A string with the type of the series.
-             *  Defaults to `'line'` in case no type is set for the chart.
+             * A string with the type of the series.
+             * Defaults to `'line'` in case no type is set for the chart.
              * Note that `'bar'`, `'gauge'` and `'solidgauge'` should be set as default series type on `<vaadin-chart>`.
              */
             type: {
@@ -169,6 +169,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
             /**
              * The name of the series as shown in the legend, tooltip etc.
+             * @type {string}
              */
             title: {
               type: String,
@@ -181,13 +182,15 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              *  - `shown`: markers are always visible
              *  - `hidden`: markers are always hidden
              *  - `auto`: markers are visible for widespread data and hidden, when data is dense *(default)*
+             * @type {ChartSeriesMarkers | undefined}
              */
             markers: {
               type: String,
               reflectToAttribute: true
             },
 
-            /** Used to connect the series to an axis; if multiple series have the same “unit”, they will share axis.
+            /**
+             * Used to connect the series to an axis; if multiple series have the same “unit”, they will share axis.
              * Displayed as a title for the axis.
              * If no unit is defined, then series will be connected to the first axis.
              */
@@ -196,27 +199,33 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               reflectToAttribute: true
             },
 
-            /** Used to group series in a different stacks.
+            /**
+             * Used to group series in a different stacks.
              * "stacking" property should be specified either for each series or in plotOptions.
              * It is recommended to place series in a single stack, when they belong to the same yAxis.
+             * @type {number | string}
              */
             stack: {
               type: String,
               reflectToAttribute: true
             },
 
-            /** The height of the neck, the lower part of the funnel.
+            /**
+             * The height of the neck, the lower part of the funnel.
              * A number defines pixel width, a percentage string defines a percentage of the plot area height. Defaults to 30%.
              * Note that this property only applies for "funnel" charts.
+             * @type {number | string}
              */
             neckPosition: {
               type: String,
               reflectToAttribute: true
             },
 
-            /** The width of the neck, the lower part of the funnel.
+            /**
+             * The width of the neck, the lower part of the funnel.
              * A number defines pixel width, a percentage string defines a percentage of the plot area width. Defaults to 30%.
              * Note that this property only applies for "funnel" charts.
+             * @type {number | string}
              */
             neckWidth: {
               type: String,
@@ -225,7 +234,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
             /**
              * Object with the configured options defined and used to create a series.
-             *
+             * @type {!ChartSeriesOptions}
              * @readonly
              */
             options: {
@@ -234,6 +243,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
             /**
              * Represents additional JSON configuration.
+             * @type {SeriesOptionsType | undefined}
              */
             additionalOptions: {
               type: Object,
@@ -264,7 +274,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
         /**
          * Method to attach a series object of type `Highcharts.Series`.
-         * @param series Object of type `Highcharts.Series`
+         * @param {!Series} series Object of type `Highcharts.Series`
          */
         setSeries(series) {
           this._series = series;

--- a/src/vaadin-chart-series.html
+++ b/src/vaadin-chart-series.html
@@ -58,7 +58,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
        * @memberof Vaadin
        * @demo demo/index.html
        */
-      class ChartSeriesElement extends Polymer.Element {
+      class ChartSeriesElement extends (class extends Polymer.Element {}) {
         static get is() {
           return 'vaadin-chart-series';
         }

--- a/src/vaadin-chart-series.html
+++ b/src/vaadin-chart-series.html
@@ -280,18 +280,21 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           this._series = series;
         }
 
+        /** @private */
         __valuesObserver(splices, series) {
           if (series) {
             series.setData(this.values);
           }
         }
 
+        /** @private */
         __additionalOptionsObserver(additionalOptions, series) {
           if (series && additionalOptions.value) {
             series.update(additionalOptions.value);
           }
         }
 
+        /** @private */
         __updateAxis(series, value, key) {
           if (!isFinite(value)) {
             this.__showWarn(`value-${key}`, 'Numbers or null');
@@ -303,6 +306,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           }
         }
 
+        /** @private */
         __valueMinObserver(valueMin, series) {
           if (valueMin === undefined || series === undefined) {
             return;
@@ -311,6 +315,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           this.__updateAxis(series, valueMin, 'min');
         }
 
+        /** @private */
         __valueMaxObserver(valueMax, series) {
           if (valueMax === undefined || series === undefined) {
             return;
@@ -319,12 +324,14 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           this.__updateAxis(series, valueMax, 'max');
         }
 
+        /** @private */
         __typeObserver(type, series) {
           if (type && series) {
             series.update({type});
           }
         }
 
+        /** @private */
         __titleObserver(title, series) {
           if (title === undefined || series === undefined) {
             return;
@@ -332,6 +339,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           series.update({name: title});
         }
 
+        /** @private */
         __stackObserver(stack, series) {
           if (stack === undefined || series === undefined) {
             return;
@@ -339,6 +347,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           series.update({stack});
         }
 
+        /** @private */
         __neckPositionObserver(neckPosition, series) {
           if (neckPosition === undefined || series === undefined) {
             return;
@@ -347,6 +356,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           series.update({neckHeight: neckPosition});
         }
 
+        /** @private */
         __neckWidthObserver(neckWidth, series) {
           if (neckWidth === undefined || series === undefined) {
             return;
@@ -355,6 +365,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           series.update({neckWidth});
         }
 
+        /** @private */
         __unitObserver(unit, valueMin, valueMax, series) {
           if (series && unit !== this.__oldUnit) {
             this.__oldUnit = unit;
@@ -381,6 +392,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           }
         }
 
+        /** @private */
         __isMarkersValid() {
           if (['shown', 'hidden', 'auto'].indexOf(this.markers) === -1) {
             this.__showWarn('markers', '"shown", "hidden" or "auto"');
@@ -389,6 +401,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           return true;
         }
 
+        /** @private */
         __markersObserver(markers, series) {
           if (markers === undefined || series === undefined) {
             return;
@@ -404,6 +417,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           });
         }
 
+        /** @private */
         get __markersConfiguration() {
           const config = {};
           switch (this.markers) {
@@ -422,6 +436,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           return config;
         }
 
+        /** @private */
         __showWarn(propertyName, acceptedValues) {
           console.warn('<vaadin-chart-series> Acceptable values for "' + propertyName + '" are ' + acceptedValues);
         }

--- a/src/vaadin-chart-series.html
+++ b/src/vaadin-chart-series.html
@@ -140,7 +140,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              * Sets the value to a series bound by 'unit' property.
              * Otherwise sets the value to the first series.
              * Undefined by default (determined from data).
-             * @type {number | null}
              */
             valueMin: {
               type: Number,
@@ -150,7 +149,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             /**
              * Value-axis maximum-value.
              * See the 'valueMin'
-             * @type {number | null}
              */
             valueMax: {
               type: Number,
@@ -250,6 +248,10 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               reflectToAttribute: true
             },
 
+            /**
+             * @type {!Series | undefined}
+             * @protected
+             */
             _series: {
               type: Object
             }

--- a/src/vaadin-chart.html
+++ b/src/vaadin-chart.html
@@ -291,9 +291,7 @@ MAGI ADD END -->
              * - `configuration.title`: The chart title.
              *
              * For detailed documentation of available API check the [API site](http://api.highcharts.com/class-reference/classes.list)
-             * @readonly
-             * @public
-             * @type {!Chart}
+             * @type {!Chart | undefined}
              */
             configuration: Object,
 
@@ -396,7 +394,7 @@ MAGI ADD END -->
 
             /**
              * Represents the subtitle of the chart.
-             * @type {string}
+             * @type {string | undefined}
              */
             subtitle: {
               type: String,
@@ -518,7 +516,7 @@ MAGI ADD END -->
           this.__mutationCallback = this.__mutationCallback.bind(this);
         }
 
-        /** @private */
+        /** @protected */
         connectedCallback() {
           super.connectedCallback();
           this.__updateStyles();
@@ -646,8 +644,9 @@ MAGI ADD END -->
         }
 
         /**
-         *  Name of the chart events to add to the configuration and its corresponding event for the chart element
-         **/
+         * Name of the chart events to add to the configuration and its corresponding event for the chart element
+         * @private
+         */
         get __chartEventNames() {
           return {
 
@@ -741,8 +740,9 @@ MAGI ADD END -->
         }
 
         /**
-         *  Name of the series events to add to the configuration and its corresponding event for the chart element
-         **/
+         * Name of the series events to add to the configuration and its corresponding event for the chart element
+         * @private
+         */
         get __seriesEventNames() {
           return {
             /**
@@ -805,8 +805,9 @@ MAGI ADD END -->
         }
 
         /**
-         *  Name of the point events to add to the configuration and its corresponding event for the chart element
-         **/
+         * Name of the point events to add to the configuration and its corresponding event for the chart element
+         * @private
+         */
         get __pointEventNames() {
           return {
             /**
@@ -868,6 +869,7 @@ MAGI ADD END -->
           };
         }
 
+        /** @private */
         get __xAxesEventNames() {
           return {
             /**
@@ -880,6 +882,7 @@ MAGI ADD END -->
           };
         }
 
+        /** @private */
         get __yAxesEventNames() {
           return {
             /**
@@ -892,6 +895,7 @@ MAGI ADD END -->
           };
         }
 
+        /** @private */
         __reflow() {
           if (!this.configuration) {
             return;
@@ -901,6 +905,7 @@ MAGI ADD END -->
           });
         }
 
+        /** @private */
         __mutationCallback() {
           const {height: componentHeight} = this.getBoundingClientRect();
           const {chartHeight} = this.configuration;
@@ -910,6 +915,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __addChildObserver() {
           Polymer.RenderStatus.beforeNextRender(this, () => {
             this._childObserver = new Polymer.FlattenedNodesObserver(this.$.slot, (info) => {
@@ -920,10 +926,12 @@ MAGI ADD END -->
           });
         }
 
+        /** @private */
         __filterSeriesNodes(node) {
           return node.nodeType === Node.ELEMENT_NODE && node instanceof Vaadin.ChartSeriesElement;
         }
 
+        /** @private */
         __addSeries(series) {
           if (this.__isSeriesEmpty(series)) {
             return;
@@ -959,6 +967,7 @@ MAGI ADD END -->
           this.__removeAxisIfEmpty();
         }
 
+        /** @private */
         __removeSeries(seriesNodes) {
           if (this.__isSeriesEmpty(seriesNodes)) {
             return;
@@ -971,6 +980,7 @@ MAGI ADD END -->
           });
         }
 
+        /** @private */
         __setYAxisProps(yAxes, yAxisId, props) {
           if (yAxisId) {
             yAxes[yAxisId].update(props);
@@ -979,10 +989,12 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __isSeriesEmpty(series) {
           return series === null || series.length === 0;
         }
 
+        /** @private */
         __cleanupAfterSeriesRemoved(series) {
           if (this.__isSeriesEmpty(series)) {
             return;
@@ -1001,6 +1013,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __initChart(options) {
           this.__initEventsListeners(options);
           if (this.timeline) {
@@ -1010,7 +1023,7 @@ MAGI ADD END -->
           }
         }
 
-        /** @private */
+        /** @protected */
         disconnectedCallback() {
           super.disconnectedCallback();
           this.__mutationObserver && this.__mutationObserver.disconnect();
@@ -1022,6 +1035,8 @@ MAGI ADD END -->
          *
          * @param {string} id contains the id that will be searched
          * @param {boolean} isXAxis indicates if it will remove x or y axes. Defaults to `false`.
+         * @return {Axis}
+         * @protected
          */
         __getAxis(id, isXAxis) {
           id = Number.parseInt(id) || id;
@@ -1037,6 +1052,8 @@ MAGI ADD END -->
          *
          * @param {Object} options axis options
          * @param {boolean} isXAxis indicates if axis is X (`true`) or Y (`false`). Defaults to `false`.
+         * @return {!Axis}
+         * @protected
          */
         __addAxis(options, isXAxis) {
           if (this.configuration) {
@@ -1048,7 +1065,8 @@ MAGI ADD END -->
         /**
          * Iterates over axes (y or x) and removes whenever it doesn't contain any series and was created for unit
          *
-         * @param {boolean}  isXAxis indicates if it will remove x or y axes. Defaults to `false`.
+         * @param {boolean} isXAxis indicates if it will remove x or y axes. Defaults to `false`.
+         * @protected
          */
         __removeAxisIfEmpty(isXAxis) {
           if (this.configuration) {
@@ -1137,6 +1155,7 @@ MAGI ADD END -->
           });
         }
 
+        /** @private */
         __makeConfigurationBuffer(target, source) {
           const _source = Highcharts.merge(source);
           const _target = Highcharts.merge(target);
@@ -1148,6 +1167,7 @@ MAGI ADD END -->
           return Highcharts.merge(_target, _source);
         }
 
+        /** @private */
         __mergeConfigurationArray(target, configuration, entry) {
           if (!configuration || !configuration[entry] || !Array.isArray(configuration[entry])) {
             return;
@@ -1165,6 +1185,7 @@ MAGI ADD END -->
           delete configuration[entry];
         }
 
+        /** @private */
         __inflateFunctions(jsonConfiguration) {
           for (const attr in jsonConfiguration) {
             if (jsonConfiguration.hasOwnProperty(attr)) {
@@ -1183,6 +1204,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __initEventsListeners(configuration) {
           this.__initChartEventsListeners(configuration);
           this.__initSeriesEventsListeners(configuration);
@@ -1191,18 +1213,22 @@ MAGI ADD END -->
           this.__initAxisEventsListeners(configuration, false);
         }
 
+        /** @private */
         __initChartEventsListeners(configuration) {
           this.__createEventListeners(this.__chartEventNames, configuration, 'chart.events', 'chart');
         }
 
+        /** @private */
         __initSeriesEventsListeners(configuration) {
           this.__createEventListeners(this.__seriesEventNames, configuration, 'plotOptions.series.events', 'series');
         }
 
+        /** @private */
         __initPointsEventsListeners(configuration) {
           this.__createEventListeners(this.__pointEventNames, configuration, 'plotOptions.series.point.events', 'point');
         }
 
+        /** @private */
         __initAxisEventsListeners(configuration, isXAxis) {
           let eventNames, axes;
 
@@ -1221,6 +1247,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __createEventListeners(eventList, configuration, pathToAdd, eventType) {
           const self = this;
           const eventObject = this.__ensureObjectPath(configuration, pathToAdd);
@@ -1725,6 +1752,11 @@ MAGI ADD END -->
           } else {
             this.$.chart.setAttribute('style', 'height:100%; width:100%;');
           }
+        }
+
+        /** @private */
+        __showWarn(propertyName, acceptedValues) {
+          console.warn('<vaadin-chart> Acceptable values for "' + propertyName + '" are ' + acceptedValues);
         }
       }
 

--- a/src/vaadin-chart.html
+++ b/src/vaadin-chart.html
@@ -258,6 +258,8 @@ MAGI ADD END -->
        * to validate your license by signing in to vaadin.com.
        *
        * @memberof Vaadin
+       * @mixes Vaadin.ThemableMixin
+       * @mixes Vaadin.ElementMixin
        * @demo demo/index.html
        */
       class ChartElement extends Vaadin.ElementMixin(Vaadin.ThemableMixin(Polymer.Element)) {
@@ -291,7 +293,7 @@ MAGI ADD END -->
              * For detailed documentation of available API check the [API site](http://api.highcharts.com/class-reference/classes.list)
              * @readonly
              * @public
-             * @type {Object}
+             * @type {!Chart}
              */
             configuration: Object,
 
@@ -299,6 +301,7 @@ MAGI ADD END -->
              * If categories are present names are used instead of numbers for the category axis.
              * The format of categories can be an `Array` with a list of categories, such as `['2010', '2011', '2012']`
              * or a mapping `Object`, like `{0:'1',9:'Target (10)', 15: 'Max'}`.
+             * @type {ChartCategories | undefined}
              */
             categories: {
               type: Object,
@@ -328,6 +331,8 @@ MAGI ADD END -->
              * except for bar charts that appear as though they have `category-position="left"`.
              *
              * Defaults to `undefined`
+             *
+             * @type {ChartCategoryPosition | undefined}
              */
             categoryPosition: {
               type: String,
@@ -348,6 +353,7 @@ MAGI ADD END -->
              * Possible values are null, "normal" or "percent".
              * If "stack" property is not defined on the vaadin-chart-series elements, then series will be put into
              * the default stack.
+             * @type {ChartStacking | undefined}
              */
             stacking: {
               type: String,
@@ -364,6 +370,7 @@ MAGI ADD END -->
 
             /**
              * Represents the title of the chart.
+             * @type {string}
              */
             title: {
               type: String,
@@ -389,6 +396,7 @@ MAGI ADD END -->
 
             /**
              * Represents the subtitle of the chart.
+             * @type {string}
              */
             subtitle: {
               type: String,
@@ -410,6 +418,7 @@ MAGI ADD END -->
 
             /**
              * Specifies the message displayed on a chart without displayable data.
+             * @type {string}
              */
             emptyText: {
               type: String,
@@ -419,6 +428,7 @@ MAGI ADD END -->
 
             /**
              * Represents additional JSON configuration.
+             * @type {Options | undefined}
              */
             additionalOptions: {
               type: Object,
@@ -530,9 +540,12 @@ MAGI ADD END -->
           });
         }
 
+        /**
+         * @return {!Options}
+         */
         get options() {
           const options = Object.assign({}, this._baseConfig);
-          Vaadin.Charts.ChartDeepMerger.__deepMerge(options, this.additionalOptions);
+          Vaadin.Charts.deepMerge(options, this.additionalOptions);
 
           if (this.type) {
             options.chart = options.chart || {};
@@ -1007,8 +1020,8 @@ MAGI ADD END -->
         /**
          * Search for axis with given `id`.
          *
-         * @param {String} id contains the id that will be searched
-         * @param {Boolean} isXAxis indicates if it will remove x or y axes. Defaults to `false`.
+         * @param {string} id contains the id that will be searched
+         * @param {boolean} isXAxis indicates if it will remove x or y axes. Defaults to `false`.
          */
         __getAxis(id, isXAxis) {
           id = Number.parseInt(id) || id;
@@ -1023,7 +1036,7 @@ MAGI ADD END -->
          * Add an axis with given options
          *
          * @param {Object} options axis options
-         * @param {Boolean} isXAxis indicates if axis is X (`true`) or Y (`false`). Defaults to `false`.
+         * @param {boolean} isXAxis indicates if axis is X (`true`) or Y (`false`). Defaults to `false`.
          */
         __addAxis(options, isXAxis) {
           if (this.configuration) {
@@ -1035,7 +1048,7 @@ MAGI ADD END -->
         /**
          * Iterates over axes (y or x) and removes whenever it doesn't contain any series and was created for unit
          *
-         * @param {Boolean}  isXAxis indicates if it will remove x or y axes. Defaults to `false`.
+         * @param {boolean}  isXAxis indicates if it will remove x or y axes. Defaults to `false`.
          */
         __removeAxisIfEmpty(isXAxis) {
           if (this.configuration) {
@@ -1056,7 +1069,7 @@ MAGI ADD END -->
          * Styling properties specified in this configuration will be ignored. To learn about chart styling
          * please see the CSS Styling section above.
          *
-         * @param {Object} jsonConfiguration Object chart configuration. Most important properties are:
+         * @param {!Options} jsonConfiguration Object chart configuration. Most important properties are:
          *
          * - chart `Object` with options regarding the chart area and plot area as well as general chart options.
          *    Detailed API for chart object is available in [API Site](http://api.highcharts.com/highcharts/chart)
@@ -1081,7 +1094,7 @@ MAGI ADD END -->
          * - zAxis `Object[]` The Z axis or depth axis for 3D plots.
          *    Detailed API for zAxis object is available in [API Site](http://api.highcharts.com/highcharts/zAxis)
          *
-         * @param {Boolean} resetConfiguration Optional boolean that should be set to true if no other chart configuration was set before or
+         * @param {boolean=} resetConfiguration Optional boolean that should be set to true if no other chart configuration was set before or
          *    if existing configuration should be discarded.
          */
         update(jsonConfiguration, resetConfiguration) {
@@ -1089,7 +1102,7 @@ MAGI ADD END -->
             this._jsonConfigurationBuffer = {};
           }
 
-          const configCopy = Vaadin.Charts.ChartDeepMerger.__deepMerge({}, jsonConfiguration);
+          const configCopy = Vaadin.Charts.deepMerge({}, jsonConfiguration);
           this.__inflateFunctions(configCopy);
           this._jsonConfigurationBuffer = this.__makeConfigurationBuffer(this._jsonConfigurationBuffer, configCopy);
 

--- a/src/vaadin-chart.html
+++ b/src/vaadin-chart.html
@@ -1335,6 +1335,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __ensureObjectPath(object, path) {
           if (typeof path !== 'string') {
             return;
@@ -1347,6 +1348,7 @@ MAGI ADD END -->
           }, object);
         }
 
+        /** @private */
         __updateOrAddCredits(credits) {
           if (this.configuration.credits) {
             this.configuration.credits.update(credits);
@@ -1355,6 +1357,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __updateOrAddAxes(axes, isX) {
           if (!Array.isArray(axes)) {
             axes = [axes];
@@ -1370,6 +1373,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __updateOrAddSeries(series) {
           if (!Array.isArray(series)) {
             throw new Error('The type of jsonConfiguration.series should be Object[]');
@@ -1380,6 +1384,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __updateOrAddSeriesInstance(seriesOptions, position) {
           if (this.configuration.series[position]) {
             this.configuration.series[position].update(seriesOptions);
@@ -1389,6 +1394,7 @@ MAGI ADD END -->
           return this.configuration.series[position];
         }
 
+        /** @private */
         __updateCategories(categories, config) {
           if (categories === undefined || !config) {
             return;
@@ -1397,6 +1403,7 @@ MAGI ADD END -->
           this.__updateOrAddAxes([{categories}], true);
         }
 
+        /** @private */
         __updateCategoryMax(max, config) {
           if (max === undefined || !config) {
             return;
@@ -1410,6 +1417,7 @@ MAGI ADD END -->
           this.__updateOrAddAxes([{max}], true);
         }
 
+        /** @private */
         __updateCategoryMin(min, config) {
           if (min === undefined || !config) {
             return;
@@ -1423,6 +1431,7 @@ MAGI ADD END -->
           this.__updateOrAddAxes([{min}], true);
         }
 
+        /** @private */
         __shouldInvert() {
           // A bar chart will never be inverted, consider using a column chart.
           // See https://stackoverflow.com/questions/11235251#answer-21739793
@@ -1436,12 +1445,14 @@ MAGI ADD END -->
           return inverted.indexOf(this.categoryPosition) >= 0;
         }
 
+        /** @private */
         __shouldFlipOpposite() {
           const opposite = ['top', 'right'];
           const oppositeBar = ['right'];
           return (this.type === 'bar' ? oppositeBar : opposite).indexOf(this.categoryPosition) >= 0;
         }
 
+        /** @private */
         __updateCategoryPosition(categoryPosition, config) {
           if (categoryPosition === undefined || !config) {
             return;
@@ -1465,6 +1476,7 @@ MAGI ADD END -->
           }));
         }
 
+        /** @private */
         __hideLegend(noLegend, config) {
           if (noLegend === undefined || !config) {
             return;
@@ -1477,6 +1489,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __updateTitle(title, config) {
           if (title === undefined || !config) {
             return;
@@ -1487,6 +1500,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __tooltipObserver(tooltip, config) {
           if (tooltip === undefined || !config) {
             return;
@@ -1495,6 +1509,7 @@ MAGI ADD END -->
           config.tooltip.update({enabled: tooltip});
         }
 
+        /** @private */
         __updateType(type, config) {
           if (type === undefined || !config) {
             return;
@@ -1507,6 +1522,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __updateSubtitle(subtitle, config) {
           if (subtitle === undefined || !config) {
             return;
@@ -1521,12 +1537,14 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __updateAdditionalOptions() {
           if (this.configuration) {
             this.update(this.additionalOptions);
           }
         }
 
+        /** @private */
         __isStackingValid() {
           if (['normal', 'percent', null].indexOf(this.stacking) === -1) {
             this.__showWarn('stacking', '"normal", "percent" or null');
@@ -1535,6 +1553,7 @@ MAGI ADD END -->
           return true;
         }
 
+        /** @private */
         __stackingObserver(stacking, config) {
           if (stacking === undefined || !config) {
             return;
@@ -1552,6 +1571,7 @@ MAGI ADD END -->
           });
         }
 
+        /** @private */
         __chart3dObserver(chart3d, config) {
           if (chart3d === undefined || !config) {
             return;
@@ -1583,6 +1603,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __polarObserver(polar, config) {
           if (polar === undefined || !config) {
             return;
@@ -1593,6 +1614,7 @@ MAGI ADD END -->
           });
         }
 
+        /** @private */
         __emptyTextObserver(emptyText, config) {
           if (emptyText === undefined || !config) {
             return;
@@ -1607,6 +1629,7 @@ MAGI ADD END -->
           config.showNoData(emptyText);
         }
 
+        /** @private */
         __callChartFunction(functionName) {
           if (this.configuration) {
             const functionToCall = this.configuration[functionName];
@@ -1617,6 +1640,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __callSeriesFunction(functionName, seriesIndex) {
           if (this.configuration && this.configuration.series[seriesIndex]) {
             const series = this.configuration.series[seriesIndex];
@@ -1628,6 +1652,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __callAxisFunction(functionName, axisCategory, axisIndex) {
           /*
            * axisCategory:
@@ -1663,6 +1688,7 @@ MAGI ADD END -->
           }
         }
 
+        /** @private */
         __callPointFunction(functionName, seriesIndex, pointIndex) {
           if (this.configuration && this.configuration.series[seriesIndex] && this.configuration.series[seriesIndex].data[pointIndex]) {
             const point = this.configuration.series[seriesIndex].data[pointIndex];
@@ -1676,6 +1702,7 @@ MAGI ADD END -->
 
         /**
          * Updates chart container and current chart style property depending on flex status
+         * @private
          */
         __updateStyles() {
           // Chrome returns default value if property is not set


### PR DESCRIPTION
Fixes #467 

UPD: generated TS definitions looks like this:

### `vaadin-chart-series.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {deepMerge, ChartElement} from './vaadin-chart.js';

declare class ChartSeriesElement extends PolymerElement {
  readonly options: ChartSeriesOptions;
  values: ChartSeriesValues|null;
  valueMin: number|null;
  valueMax: number|null;
  type: string|null|undefined;
  title: string;
  markers: ChartSeriesMarkers|null|undefined;
  unit: string|null|undefined;
  stack: number|string;
  neckPosition: number|string;
  neckWidth: number|string;
  additionalOptions: SeriesOptionsType|null|undefined;
  setSeries(series: Series): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-chart-series": ChartSeriesElement;
  }
}

export {ChartSeriesElement};

import {ChartSeriesOptions} from '../@types/interfaces';

import {ChartSeriesValues} from '../@types/interfaces';

import {ChartSeriesMarkers} from '../@types/interfaces';

import {SeriesOptionsType} from 'highcharts';

import {Series} from 'highcharts';
```

### `vaadin-chart.d.ts`

```ts

import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {FlattenedNodesObserver} from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';

import {beforeNextRender} from '@polymer/polymer/lib/utils/render-status.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {ChartSeriesElement} from './vaadin-chart-series.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

export {deepMerge};

declare function deepMerge(): any;

declare class ChartElement extends
  ThemableMixin(
  ElementMixin(
  PolymerElement)) {
  readonly options: Options;
  configuration: Chart;
  categories: ChartCategories|null|undefined;
  categoryMax: number|null|undefined;
  categoryMin: number|null|undefined;
  categoryPosition: ChartCategoryPosition|null|undefined
  noLegend: boolean|null|undefined;
  stacking: ChartStacking|null|undefined;
  timeline: boolean|null|undefined;
  title: string;
  tooltip: boolean|null|undefined;
  type: string|null|undefined;
  subtitle: string;
  chart3d: boolean|null|undefined;
  emptyText: string;
  additionalOptions: Options|null|undefined;
  polar: boolean|null|undefined;
  static _finalizeClass(): void;
  update(jsonConfiguration: Options, resetConfiguration?: boolean): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-chart": ChartElement;
  }
}

export {ChartElement};

import {Options} from 'highcharts';

import {Chart} from 'highcharts';

import {ChartCategories} from '../@types/interfaces';

import {ChartCategoryPosition} from '../@types/interfaces';

import {ChartStacking} from '../@types/interfaces';

```

## Findings

- We have to use `string` type for `title` property to match native title attribute.

## Note

The `highcharts.d.ts` file can be found here: https://unpkg.com/highcharts@8.1.0/highcharts.d.ts
