### PR TITLE
fix: enable accessibility for charts

### DIFF
--- a/src/vaadin-chart-series.html
+++ b/src/vaadin-chart-series.html
@@ -64,9 +64,7 @@ See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the comple
         }
 
         get options() {
-          // Should be {}, workaround for https://github.com/highcharts/highcharts/issues/13482
-          const baseConfig = {accessibility: {enabled: false}};
-          const options = Vaadin.Charts.deepMerge(baseConfig, this.additionalOptions);
+          const options = Vaadin.Charts.deepMerge({}, this.additionalOptions);
 
           if (this.type) {
             options.type = this.type;


### PR DESCRIPTION
related to #474 

Workaround mentioned (highcharts/highcharts#13482) was already fixed in 8.1.1 (https://www.highcharts.com/blog/changelog/). 

Vaadin-charts already depend on 8.1.2.