### PR TITLE
fix: enable accessibility for charts

### DIFF
--- a/src/vaadin-chart-series.html
+++ b/src/vaadin-chart-series.html
@@ -64,9 +64,7 @@ See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the comple
         }
 
         get options() {
-          // Should be {}, workaround for https://github.com/highcharts/highcharts/issues/13482
-          const baseConfig = {accessibility: {enabled: false}};
-          const options = Vaadin.Charts.deepMerge(baseConfig, this.additionalOptions);
+          const options = Vaadin.Charts.deepMerge({}, this.additionalOptions);
 
           if (this.type) {
             options.type = this.type;

--- a/test/element-api-chart-series-test.html
+++ b/test/element-api-chart-series-test.html
@@ -258,11 +258,9 @@
       });
 
       function markersVisible(container) {
-        // Markers are visible only if there's a child in highcharts-markers with visibility other than 'hidden'
-        return Array.from(container.querySelectorAll('.highcharts-markers'))
-          .map(e => !!e.firstChild && (!e.firstChild.attributes.hasOwnProperty('visibility')
-              || e.firstChild.attributes.visibility.value !== 'hidden'))
-          .reduce((e1, e2) => e1 && e2);
+        return Array.from(container.querySelectorAll('.highcharts-markers')).every((g) => {
+          return Boolean(g.firstChild && getComputedStyle(g.firstChild).opacity !== '0');
+        });
       }
 
       it('should have markers by default for widespread data', function(done) {

--- a/theme/vaadin-chart-default-theme.html
+++ b/theme/vaadin-chart-default-theme.html
@@ -968,6 +968,11 @@ text.highcharts-drilldown-data-label,
   box-shadow: -3px 3px 10px #888;
 }
 
+/* CSS for markers */
+.highcharts-a11y-markers-hidden .highcharts-point:not(.highcharts-point-hover):not(.highcharts-a11y-marker-visible),
+.highcharts-a11y-marker-hidden {
+    opacity: 0;
+}
 
 /* stylelint-enable */
     </style>


### PR DESCRIPTION
Migrated PR #558 to the repo so tests can run.

related to #474 

Workaround mentioned (highcharts/highcharts#13482) was already fixed in 8.1.1 (https://www.highcharts.com/blog/changelog/). 

Vaadin-charts already depend on 8.1.2.