### PR TITLE
fix: chart reflow if container is flex child

### DIFF
--- a/src/vaadin-chart.html
+++ b/src/vaadin-chart.html
@@ -65,8 +65,17 @@ MAGI ADD END -->
 
       /* https://github.com/highcharts/highcharts/issues/4649 */
       /* https://github.com/vaadin/web-components/issues/2171 */
+      /* Constrain SVG size to container size, which prevents
+          overflow if the container is a flex child without
+          explicit overflow attribute */
       .highcharts-container svg {
-        width: 100% !important;
+        max-width: 100%;
+      }
+
+      /* Do not constrain size if an explicit width has been set
+          on the chart */
+      :host([has-explicit-width]) .highcharts-container svg {
+        max-width: unset;
       }
 
       :host(.ff-lt-68) {
@@ -1103,6 +1112,8 @@ MAGI ADD END -->
           } else {
             this.configuration = Highcharts.chart(this.$.chart, options);
           }
+          this.__patchSetSize();
+          this.__updateExplicitSizeAttribute();
 
           // Workaround for https://github.com/highcharts/highcharts/issues/9978
           const elementsToChange = [
@@ -1118,6 +1129,33 @@ MAGI ADD END -->
               el.style.top = '-999em';
             }
           });
+        }
+
+        __patchSetSize() {
+          if (!this.configuration) {
+            return;
+          }
+          // Patch HighCharts.Chart.setSize to get notified about resizes
+          const self = this;
+          const origSetSize = this.configuration.setSize.bind(this.configuration);
+          this.configuration.setSize = function setSize() {
+            origSetSize.apply(this.configuration, arguments);
+            self.__updateExplicitSizeAttribute();
+          };
+        }
+
+        __updateExplicitSizeAttribute() {
+          if (!this.configuration) {
+            return;
+          }
+
+          const hasExplicitWidth = !!this.configuration.options.chart.width;
+
+          if (hasExplicitWidth) {
+            this.setAttribute('has-explicit-width', '');
+          } else {
+            this.removeAttribute('has-explicit-width');
+          }
         }
 
         /** @private */
@@ -1231,6 +1269,7 @@ MAGI ADD END -->
             }
 
             this.configuration.update(this._jsonConfigurationBuffer);
+            this.__updateExplicitSizeAttribute();
             if (this._jsonConfigurationBuffer.credits) {
               this.__updateOrAddCredits(this._jsonConfigurationBuffer.credits);
             }


### PR DESCRIPTION
## Description

Preliminary solution for fixing the regression where setting an explicit width on a chart through the Highcharts API does not work anymore (https://github.com/vaadin/web-components/issues/2600), which was introduced by a recent BFP fix (#580).

The previous fix introduced a CSS rule that applied a `width: 100% !important` on the inner Highcharts SVG, which breaks charts that have an explicit size set through the Highcharts API. This PR changes the style rule to use `max-width: 100%`, which still fixes the original issue of the BFP (chart width exceeds container width, if container is a flex child), but is more flexible in terms of sizing. 

There is still one scenario not covered by this style rule, which is setting an explicit chart width that is larger than 100% of the container. To fix this I introduced a new attribute `has-explicit-width` on `<vaadin-chart>` which gets set / updated whenever an explicit width is set through the Highcharts API. If the attribute is set, then the style rule mentioned above will be disabled to respect the explicit size of the SVG. This solution involves some monkey-patching of `Highcharts.Chart` - we need to decide if this case is worth doing that, or if we just don't want to cover it.

Still needs tests to verify that explicit sizing works, and that the `has-explicit-width` attribute logic works.

Fixes https://github.com/vaadin/web-components/issues/2600

## Type of change

- [x] Bugfix
